### PR TITLE
Storecertificates

### DIFF
--- a/SafeguardDevOpsService/Attributes/SafeguardAuthorizationBaseAttribute.cs
+++ b/SafeguardDevOpsService/Attributes/SafeguardAuthorizationBaseAttribute.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Linq;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using OneIdentity.DevOps.Logic;
-using RestSharp;
+using OneIdentity.DevOps.Authorization;
 using RestSharp.Extensions;
 
-namespace OneIdentity.DevOps.Authorization
+namespace OneIdentity.DevOps.Attributes
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
     public class SafeguardAuthorizationBaseAttribute : Attribute

--- a/SafeguardDevOpsService/Attributes/SafeguardSessionKeyAuthorizationAttribute.cs
+++ b/SafeguardDevOpsService/Attributes/SafeguardSessionKeyAuthorizationAttribute.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Linq;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using OneIdentity.DevOps.Authorization;
 using OneIdentity.DevOps.Logic;
 using OneIdentity.SafeguardDotNet;
 
-namespace OneIdentity.DevOps.Authorization
+namespace OneIdentity.DevOps.Attributes
 {
     public class SafeguardSessionKeyAuthorizationAttribute : SafeguardAuthorizationBaseAttribute, IAuthorizationFilter
     {

--- a/SafeguardDevOpsService/Attributes/SafeguardTokenAuthorizationAttribute.cs
+++ b/SafeguardDevOpsService/Attributes/SafeguardTokenAuthorizationAttribute.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Linq;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using OneIdentity.DevOps.Authorization;
 using OneIdentity.DevOps.Logic;
 
-namespace OneIdentity.DevOps.Authorization
+namespace OneIdentity.DevOps.Attributes
 {
     public class SafeguardTokenAuthorizationAttribute : SafeguardAuthorizationBaseAttribute, IAuthorizationFilter
     {

--- a/SafeguardDevOpsService/Attributes/UnhandledExceptionErrorAttribute.cs
+++ b/SafeguardDevOpsService/Attributes/UnhandledExceptionErrorAttribute.cs
@@ -6,7 +6,6 @@ using OneIdentity.DevOps.Extensions;
 
 namespace OneIdentity.DevOps.Attributes
 {
-//    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public class UnhandledExceptionErrorAttribute : ExceptionFilterAttribute
     {
         private readonly Serilog.ILogger _logger = Serilog.Log.Logger;
@@ -28,78 +27,6 @@ namespace OneIdentity.DevOps.Attributes
             }
 
             context.ExceptionHandled = true;
-
-//             string message;
-//
-//             if (context.Exception.FlattenException() is DevOpsException devOpsException)
-//             {
-//                 var response = devOpsException.ResponseMessage;
-//                 string errorMessage;
-//                 // if (response != null)
-//                 // {
-//                 //     response.Headers.Remove(HttpHeaderNames.Server); // remove so it doesn't get duplicated by system
-//                 //
-//                 //     try
-//                 //     {
-//                 //         var apiError = AsyncHelper.RunSync(response.Content.ReadAsAsync<ApiError>); // strip out extra data
-//                 //         var newResponse = context.Request.CreateResponse(response.StatusCode, apiError);
-//                 //         context.Exception = new HttpResponseException(newResponse);
-//                 //
-//                 //         errorMessage = $"{JsonConvert.SerializeObject(apiError)}";
-//                 //     }
-//                 //     catch
-//                 //     {
-//                 //         context.Exception = new HttpResponseException(response);
-//                 //         errorMessage = AsyncHelper.RunSync(response.Content.ReadAsStringAsync);
-//                 //     }
-//                 // }
-//                 // else
-//                 // {
-//                     context.Exception = devOpsException;
-//                     errorMessage = devOpsException.Message;
-// //                }
-//
-//                 message = $"Executed action: {context.Request.Method.Method} {context.Request.RequestUri} = {context.Exception?.GetType().FullName}: {(int)(response?.StatusCode ?? HttpStatusCode.InternalServerError)} {(response?.StatusCode ?? HttpStatusCode.InternalServerError).ToString()}\r\n{errorMessage}";
-//                 _logger.Error(message);
-//             }
-//
-//             if (context.Exception is HttpResponseException)
-//                 return;
-//
-//             var ex = GetExceptionForDetail(context);
-//             var request = context.Request;
-// //            var culture = request.CultureInfo();
-//
-//             // var t = ApiError.GetErrorDetail(ex, culture);
-//             // context.Response = request.CreateResponse(t.Item1, t.Item2);
-//
-//             // if (context.Response.Content != null)
-//             // {
-//             //     context.Response.Content.Headers.Remove(HttpHeaderNames.ContentLanguage);
-//             //     context.Response.Content.Headers.Add(HttpHeaderNames.ContentLanguage, culture.Name);
-//             // }
-//
-//             message = $"Executed action: {context.Request.Method.Method} {context.Request.RequestUri} = {context.Exception?.GetType().FullName}: {(int)context.Response.StatusCode} {context.Response.StatusCode.ToString()}\r\n{context.Exception?.Message}";
-//             if (context.Response.StatusCode == HttpStatusCode.InternalServerError)
-//             {
-//                 _logger.Error(context.Exception, message);
-//             }
-//             else
-//             {
-//                 _logger.Warning(context.Exception, message);
-//             }
         }
-
-        // private static Exception GetExceptionForDetail(HttpActionExecutedContext context)
-        // {
-        //     if (context.Exception == null)
-        //         return null;
-        //
-        //     var exception = context.Exception;
-        //     if (exception.InnerException != null && exception is TargetInvocationException)
-        //         exception = exception.InnerException;
-        //
-        //     return exception;
-        // }
     }
 }

--- a/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
@@ -22,6 +22,9 @@ namespace OneIdentity.DevOps.ConfigDb
 
         string UserCertificateThumbprint { get; set; }
         string UserCertificateBase64Data { get; set; }
-        X509Certificate2 UserCertificate { get; }
+        string CsrBase64Data { get; set; }
+        string CsrPrivateKeyBase64Data { get; set; }
+
+        X509Certificate2 UserCertificate { get; set; }
     }
 }

--- a/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using OneIdentity.DevOps.Data;
 
@@ -18,10 +19,13 @@ namespace OneIdentity.DevOps.ConfigDb
         string SafeguardAddress { get; set; }
         int? ApiVersion { get; set; }
         bool? IgnoreSsl { get; set; }
+        int? A2aUserId { get; set; }
+        int? A2aRegistrationId { get; set; }
         string SigningCertificate { get; set; }
 
         string UserCertificateThumbprint { get; set; }
         string UserCertificateBase64Data { get; set; }
+        string UserCertificatePassphrase { get; set; }
         string CsrBase64Data { get; set; }
         string CsrPrivateKeyBase64Data { get; set; }
 

--- a/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
@@ -29,6 +29,8 @@ namespace OneIdentity.DevOps.ConfigDb
 
         private const string UserCertificateThumbprintKey = "UserCertThumbprint";
         private const string UserCertificateDataKey = "UserCertData";
+        private const string CsrDataKey = "CertificateSigningRequestData";
+        private const string CsrPrivateKeyDataKey = "CertificateSigningRequestPrivateKeyData";
 
         public LiteDbConfigurationRepository()
         {
@@ -156,6 +158,18 @@ namespace OneIdentity.DevOps.ConfigDb
             set => SetSimpleSetting(UserCertificateDataKey, value);
         }
 
+        public string CsrBase64Data
+        {
+            get => GetSimpleSetting(CsrDataKey);
+            set => SetSimpleSetting(CsrDataKey, value);
+        }
+
+        public string CsrPrivateKeyBase64Data
+        {
+            get => GetSimpleSetting(CsrPrivateKeyDataKey);
+            set => SetSimpleSetting(CsrPrivateKeyDataKey, value);
+        }
+
         public X509Certificate2 UserCertificate
         {
             get
@@ -165,8 +179,8 @@ namespace OneIdentity.DevOps.ConfigDb
                     try
                     {
                         var bytes = Convert.FromBase64String(UserCertificateBase64Data);
-                        var cert = new X509Certificate2();
-                        cert.Import(bytes);
+                        var cert = new X509Certificate2(bytes);
+                        return cert;
                     }
                     catch (Exception)
                     {
@@ -199,6 +213,19 @@ namespace OneIdentity.DevOps.ConfigDb
                 }
 
                 return null;
+            }
+
+            set
+            {
+                if (value != null)
+                {
+                    UserCertificateBase64Data = Convert.ToBase64String(value.Export(X509ContentType.Pfx));
+                }
+                else
+                {
+                    UserCertificateBase64Data = null;
+                    UserCertificateThumbprint = null;
+                }
             }
         }
 

--- a/SafeguardDevOpsService/Controllers/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/SafeguardController.cs
@@ -66,6 +66,20 @@ namespace OneIdentity.DevOps.Controllers
         }
 
         /// <summary>
+        /// DELETE ME.  This endpoint is just for development.
+        /// </summary>
+        /// <response code="200">Success</response>
+        /// <response code="404">Not found</response>
+        [SafeguardSessionKeyAuthorization]
+        [HttpGet("CreateA2AUser")]
+        public ActionResult<Safeguard> CreateA2AUser([FromServices] ISafeguardLogic safeguard)
+        {
+            safeguard.CreateA2AUser();
+
+            return Ok();
+        }
+
+        /// <summary>
         /// Configure a Safeguard configuration for the DevOps service to use.
         /// </summary>
         /// <response code="200">Success</response>
@@ -96,10 +110,10 @@ namespace OneIdentity.DevOps.Controllers
         /// </summary>
         /// <response code="200">Success</response>
         /// <response code="404">Not found</response>
-        [HttpGet("ClientCertificate/{thumbPrint}")]
-        public ActionResult<ClientCertificate> GetClientCertificate([FromServices] ISafeguardLogic safeguard, string thumbPrint)
+        [HttpGet("ClientCertificate")]
+        public ActionResult<ClientCertificate> GetClientCertificate([FromServices] ISafeguardLogic safeguard)
         {
-            var certificate = safeguard.GetClientCertificate(thumbPrint);
+            var certificate = safeguard.GetClientCertificate();
             if (certificate == null)
                 return NotFound();
 
@@ -124,12 +138,24 @@ namespace OneIdentity.DevOps.Controllers
         /// </summary>
         /// <response code="200">Success</response>
         /// <response code="404">Not found</response>
-        [HttpDelete("ClientCertificate/{thumbPrint}")]
-        public ActionResult RemoveClientCertificate([FromServices] ISafeguardLogic safeguard, string thumbPrint)
+        [HttpDelete("ClientCertificate")]
+        public ActionResult RemoveClientCertificate([FromServices] ISafeguardLogic safeguard)
         {
-            safeguard.RemoveClientCertificate(thumbPrint);
+            safeguard.RemoveClientCertificate();
 
             return NoContent();
+        }
+
+        /// <summary>
+        /// Get a CSR can be signed and uploaded back to the DevOps service.
+        /// </summary>
+        /// <response code="200">Success</response>
+        /// <response code="404">Not found</response>
+        [HttpGet("CSR")]
+        public ActionResult<string> GetClientCSR([FromServices] ISafeguardLogic safeguard, [FromQuery] int? size, [FromQuery] string subjectName)
+        {
+            var csr = safeguard.GetClientCSR(size, subjectName);
+            return Ok(csr);
         }
 
         /// <summary>

--- a/SafeguardDevOpsService/Controllers/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/SafeguardController.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using OneIdentity.DevOps.Authorization;
 using OneIdentity.DevOps.Data;
 using OneIdentity.DevOps.Logic;
@@ -87,6 +89,47 @@ namespace OneIdentity.DevOps.Controllers
             safeguard.DeleteSafeguardData();
             return NoContent();
             // TODO: error handling?
+        }
+
+        /// <summary>
+        /// Get an installed client certificate by thumbprint.
+        /// </summary>
+        /// <response code="200">Success</response>
+        /// <response code="404">Not found</response>
+        [HttpGet("ClientCertificate/{thumbPrint}")]
+        public ActionResult<ClientCertificate> GetClientCertificate([FromServices] ISafeguardLogic safeguard, string thumbPrint)
+        {
+            var certificate = safeguard.GetClientCertificate(thumbPrint);
+            if (certificate == null)
+                return NotFound();
+
+            return Ok(certificate);
+        }
+
+        /// <summary>
+        /// Install a trusted certificate.
+        /// </summary>
+        /// <response code="200">Success</response>
+        /// <response code="400">Bad request</response>
+        [HttpPost("ClientCertificate")]
+        public ActionResult InstallClientCertificate([FromServices] ISafeguardLogic safeguard, [FromForm]ClientCertificatePfx certFile)
+        {
+            var size = certFile.file.Length;
+            safeguard.InstallClientCertificate(certFile);
+            return Ok();
+        }
+
+        /// <summary>
+        /// Remove an installed client certificate by thumbprint.
+        /// </summary>
+        /// <response code="200">Success</response>
+        /// <response code="404">Not found</response>
+        [HttpDelete("ClientCertificate/{thumbPrint}")]
+        public ActionResult RemoveClientCertificate([FromServices] ISafeguardLogic safeguard, string thumbPrint)
+        {
+            safeguard.RemoveClientCertificate(thumbPrint);
+
+            return NoContent();
         }
 
         /// <summary>

--- a/SafeguardDevOpsService/Controllers/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/SafeguardController.cs
@@ -1,7 +1,5 @@
-﻿using System.Net;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using OneIdentity.DevOps.Authorization;
+﻿using Microsoft.AspNetCore.Mvc;
+using OneIdentity.DevOps.Attributes;
 using OneIdentity.DevOps.Data;
 using OneIdentity.DevOps.Logic;
 
@@ -24,13 +22,54 @@ namespace OneIdentity.DevOps.Controllers
         /// <response code="200">Success</response>
         /// <response code="404">Not found</response>
         [SafeguardSessionKeyAuthorization]
+        [UnhandledExceptionError]
         [HttpGet]
-        public ActionResult<Safeguard> GetSafeguard([FromServices] ISafeguardLogic safeguard)
+        public ActionResult<ManagementConnection> GetSafeguard([FromServices] ISafeguardLogic safeguard)
         {
-            var availability = safeguard.GetSafeguardData();
-            if (availability == null)
-                return NotFound("No Safeguard has not been configured");
-            return Ok(availability);
+            var managementConnection = safeguard.GetConnection();
+
+            // var availability = safeguard.GetSafeguardData();
+            // if (availability == null)
+            //     return NotFound("No Safeguard has not been configured");
+            return Ok(managementConnection);
+            // TODO: error handling?
+        }
+
+        /// <summary>
+        /// Configure a Safeguard configuration for the DevOps service to use.
+        /// </summary>
+        /// <response code="200">Success</response>
+        /// <response code="400">Bad request</response>
+        [SafeguardSessionKeyAuthorization]
+        [UnhandledExceptionError]
+        [HttpPut]
+        public ActionResult<ManagementConnection> SetSafeguard([FromServices] ISafeguardLogic safeguard,
+            [FromBody] SafeguardData safeguardData, [FromQuery] bool configure = false)
+        {
+            var managementConnection = new ManagementConnection()
+            {
+                Appliance = safeguard.SetSafeguardData(safeguardData)
+            };
+
+            if (configure)
+            {
+                safeguard.ConfigureDevOpsService();
+                managementConnection = safeguard.GetConnection();
+            }
+
+            return Ok(managementConnection);
+        }
+
+        /// <summary>
+        /// Deletes the current Safeguard configuration so that none is in use with the DevOps service.
+        /// </summary>
+        /// <response code="204">Success</response>
+        [UnhandledExceptionError]
+        [HttpDelete]
+        public ActionResult DeleteSafeguard([FromServices] ISafeguardLogic safeguard)
+        {
+            safeguard.DeleteSafeguardData();
+            return NoContent();
             // TODO: error handling?
         }
 
@@ -40,6 +79,7 @@ namespace OneIdentity.DevOps.Controllers
         /// <response code="200">Success</response>
         /// <response code="404">Not found</response>
         [SafeguardTokenAuthorization]
+        [UnhandledExceptionError]
         [HttpGet("Logon")]
         public ActionResult<Safeguard> GetSafeguardLogon([FromServices] ISafeguardLogic safeguard)
         {
@@ -56,6 +96,7 @@ namespace OneIdentity.DevOps.Controllers
         /// <response code="200">Success</response>
         /// <response code="404">Not found</response>
         [SafeguardSessionKeyAuthorization]
+        [UnhandledExceptionError]
         [HttpGet("Logoff")]
         public ActionResult<Safeguard> GetSafeguardLogoff([FromServices] ISafeguardLogic safeguard)
         {
@@ -66,50 +107,11 @@ namespace OneIdentity.DevOps.Controllers
         }
 
         /// <summary>
-        /// DELETE ME.  This endpoint is just for development.
-        /// </summary>
-        /// <response code="200">Success</response>
-        /// <response code="404">Not found</response>
-        [SafeguardSessionKeyAuthorization]
-        [HttpGet("CreateA2AUser")]
-        public ActionResult<Safeguard> CreateA2AUser([FromServices] ISafeguardLogic safeguard)
-        {
-            safeguard.CreateA2AUser();
-
-            return Ok();
-        }
-
-        /// <summary>
-        /// Configure a Safeguard configuration for the DevOps service to use.
-        /// </summary>
-        /// <response code="200">Success</response>
-        /// <response code="400">Bad request</response>
-        [HttpPut]
-        public ActionResult<Safeguard> SetSafeguard([FromServices] ISafeguardLogic safeguard,
-            [FromBody] SafeguardData safeguardData)
-        {
-            var availability = safeguard.SetSafeguardData(safeguardData);
-            return Ok(availability);
-            // TODO: error handling?
-        }
-
-        /// <summary>
-        /// Deletes the current Safeguard configuration so that none is in use with the DevOps service.
-        /// </summary>
-        /// <response code="204">Success</response>
-        [HttpDelete]
-        public ActionResult DeleteSafeguard([FromServices] ISafeguardLogic safeguard)
-        {
-            safeguard.DeleteSafeguardData();
-            return NoContent();
-            // TODO: error handling?
-        }
-
-        /// <summary>
         /// Get an installed client certificate by thumbprint.
         /// </summary>
         /// <response code="200">Success</response>
         /// <response code="404">Not found</response>
+        [UnhandledExceptionError]
         [HttpGet("ClientCertificate")]
         public ActionResult<ClientCertificate> GetClientCertificate([FromServices] ISafeguardLogic safeguard)
         {
@@ -125,10 +127,10 @@ namespace OneIdentity.DevOps.Controllers
         /// </summary>
         /// <response code="200">Success</response>
         /// <response code="400">Bad request</response>
+        [UnhandledExceptionError]
         [HttpPost("ClientCertificate")]
-        public ActionResult InstallClientCertificate([FromServices] ISafeguardLogic safeguard, [FromForm]ClientCertificatePfx certFile)
+        public ActionResult InstallClientCertificate([FromServices] ISafeguardLogic safeguard, ClientCertificate certFile)
         {
-            var size = certFile.file.Length;
             safeguard.InstallClientCertificate(certFile);
             return Ok();
         }
@@ -138,6 +140,7 @@ namespace OneIdentity.DevOps.Controllers
         /// </summary>
         /// <response code="200">Success</response>
         /// <response code="404">Not found</response>
+        [UnhandledExceptionError]
         [HttpDelete("ClientCertificate")]
         public ActionResult RemoveClientCertificate([FromServices] ISafeguardLogic safeguard)
         {
@@ -151,6 +154,7 @@ namespace OneIdentity.DevOps.Controllers
         /// </summary>
         /// <response code="200">Success</response>
         /// <response code="404">Not found</response>
+        [UnhandledExceptionError]
         [HttpGet("CSR")]
         public ActionResult<string> GetClientCSR([FromServices] ISafeguardLogic safeguard, [FromQuery] int? size, [FromQuery] string subjectName)
         {
@@ -158,46 +162,49 @@ namespace OneIdentity.DevOps.Controllers
             return Ok(csr);
         }
 
-        /// <summary>
-        /// Get the current management connection to Safeguard in use by the DevOps service.
-        /// </summary>
-        /// <response code="200">Success</response>
-        /// <response code="404">Not found</response>
-        [HttpGet("ManagementConnection")]
-        public ActionResult<ManagementConnection> ConnectSafeguard([FromServices] ISafeguardLogic safeguard)
-        {
-            var connection = safeguard.GetConnection();
-            if (connection == null)
-                return NotFound("Safeguard is not connected");
-            return Ok(connection);
-            // TODO: error handling?
-        }
-
-        /// <summary>
-        /// Create the management connection to Safeguard to use with the DevOps service.
-        /// </summary>
-        /// <response code="200">Success</response>
-        /// <response code="404">Not found</response>
-        [HttpPut("ManagementConnection")]
-        public ActionResult<ManagementConnection> ConnectSafeguard([FromServices] ISafeguardLogic safeguard,
-            [FromBody] ManagementConnectionData connectionData)
-        {
-            var connection = safeguard.Connect(connectionData);
-            return Ok(connection);
-            // TODO: error handling?
-        }
-
-        /// <summary>
-        /// Remove the management connection to Safeguard so that none is in use with the DevOps service.
-        /// </summary>
-        /// <response code="200">Success</response>
-        /// <response code="404">Not found</response>
-        [HttpDelete("ManagementConnection")]
-        public ActionResult DisconnectSafeguard([FromServices] ISafeguardLogic safeguard)
-        {
-            safeguard.Disconnect();
-            return Ok();
-            // TODO: error handling?
-        }
+        // /// <summary>
+        // /// Get the current management connection to Safeguard in use by the DevOps service.
+        // /// </summary>
+        // /// <response code="200">Success</response>
+        // /// <response code="404">Not found</response>
+        // [UnhandledExceptionError]
+        // [HttpGet("ManagementConnection")]
+        // public ActionResult<ManagementConnection> ConnectSafeguard([FromServices] ISafeguardLogic safeguard)
+        // {
+        //     var connection = safeguard.GetConnection();
+        //     if (connection == null)
+        //         return NotFound("Safeguard is not connected");
+        //     return Ok(connection);
+        //     // TODO: error handling?
+        // }
+        //
+        // /// <summary>
+        // /// Create the management connection to Safeguard to use with the DevOps service.
+        // /// </summary>
+        // /// <response code="200">Success</response>
+        // /// <response code="404">Not found</response>
+        // [UnhandledExceptionError]
+        // [HttpPut("ManagementConnection")]
+        // public ActionResult<ManagementConnection> ConnectSafeguard([FromServices] ISafeguardLogic safeguard,
+        //     [FromBody] ManagementConnectionData connectionData)
+        // {
+        //     var connection = safeguard.Connect(connectionData);
+        //     return Ok(connection);
+        //     // TODO: error handling?
+        // }
+        //
+        // /// <summary>
+        // /// Remove the management connection to Safeguard so that none is in use with the DevOps service.
+        // /// </summary>
+        // /// <response code="200">Success</response>
+        // /// <response code="404">Not found</response>
+        // [UnhandledExceptionError]
+        // [HttpDelete("ManagementConnection")]
+        // public ActionResult DisconnectSafeguard([FromServices] ISafeguardLogic safeguard)
+        // {
+        //     safeguard.Disconnect();
+        //     return Ok();
+        //     // TODO: error handling?
+        // }
     }
 }

--- a/SafeguardDevOpsService/Data/ClientCertificate.cs
+++ b/SafeguardDevOpsService/Data/ClientCertificate.cs
@@ -1,0 +1,99 @@
+using System;
+using System.ComponentModel;
+
+namespace OneIdentity.DevOps.Data
+{
+    /// <summary>
+    /// Represents a certificate from a certificate store on the appliance
+    /// </summary>
+    public class ClientCertificate
+    {
+        private DateTime _notBefore;
+        private DateTime _notAfter;
+
+        public ClientCertificate()
+        {
+            Subject = "";
+        }
+
+        /// <summary>
+        /// The Subject of the certificate (Read-only)
+        /// </summary>
+        [ReadOnly(true)]
+        public string Subject { get; set; }
+
+        /// <summary>
+        /// The CA that issued the certificate (Read-only)
+        /// </summary>
+        [ReadOnly(true)]
+        public string IssuedBy { get; set; }
+
+        /// <summary>
+        /// The date the certificate becomes valid (Read-only)
+        /// </summary>
+        [ReadOnly(true)]
+        public DateTime NotBefore
+        {
+            get { return _notBefore; }
+            set { _notBefore = DateTime.SpecifyKind(value, DateTimeKind.Utc); }
+        }
+
+        /// <summary>
+        /// The date the certificate expires (Read-only)
+        /// </summary>
+        [ReadOnly(true)]
+        public DateTime NotAfter
+        {
+            get { return _notAfter; }
+            set { _notAfter = DateTime.SpecifyKind(value, DateTimeKind.Utc); }
+        }
+
+        /// <summary>
+        /// The thumbprint of the certificate (Read-only)
+        /// </summary>
+        [ReadOnly(true)]
+        public string Thumbprint { get; set; }
+
+        /// <summary>
+        /// Base64 representation of the certificate (write-only)
+        /// </summary>
+        public string Base64CertificateData { get; set; }
+
+        /// <summary>
+        /// Passphase to decode the Base64 representation of the certificate (write-only)
+        /// </summary>
+        public string Passphrase { get; set; }
+
+        protected bool Equals(ClientCertificate other)
+        {
+            return string.Equals(Subject, other.Subject) && string.Equals(IssuedBy, other.IssuedBy) && NotBefore.Equals(other.NotBefore) && NotAfter.Equals(other.NotAfter) && string.Equals(Thumbprint, other.Thumbprint);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((ClientCertificate) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Subject?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (IssuedBy?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ NotBefore.GetHashCode();
+                hashCode = (hashCode * 397) ^ NotAfter.GetHashCode();
+                hashCode = (hashCode * 397) ^ (Thumbprint?.GetHashCode() ?? 0);
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            return "{ Subject : " + Subject + ", Issuer: " + IssuedBy + ", Thumbprint: " + Thumbprint + " }";
+        }
+        
+    }
+}

--- a/SafeguardDevOpsService/Data/ManagementConnection.cs
+++ b/SafeguardDevOpsService/Data/ManagementConnection.cs
@@ -23,6 +23,7 @@ namespace OneIdentity.DevOps.Data
         public string IdentityProviderName { get; set; }
         public string UserName { get; set; }
         public string[] AdminRoles { get; set; }
+        public string A2ARegistrationName { get; set; }
 
         public string SessionKey
         {

--- a/SafeguardDevOpsService/Data/Spp/A2AUser.cs
+++ b/SafeguardDevOpsService/Data/Spp/A2AUser.cs
@@ -1,0 +1,26 @@
+﻿
+using OneIdentity.DevOps.Logic;
+
+namespace OneIdentity.DevOps.Data.Spp
+{
+    public class A2AUser
+    {
+        public int Id { get; set; }
+        public string UserName { get; set; } = WellKnownData.DevOpsUserName;
+        public string Description { get; set; } = "Safeguard User for DevOps Service";
+        public string DisplayName { get; set; } = "Safeguard DevOps User";
+        public string LastName { get; set; } = "DevOps Service";
+        public string FirstName { get; set; } = "DevOps User";
+        public bool Disabled { get; set; } = false;
+        public bool Locked { get; set; } = false;
+        public bool PasswordNeverExpires { get; set; } = true;
+        public int PrimaryAuthenticationProviderId { get; set; } = -2;
+        public string PrimaryAuthenticationIdentity { get; set; }  //Thumbprint
+        public string TimeZoneId { get; set; } = "UTC";
+        public bool RequireCertificateAuthentication { get; set; } = true;
+        public int IdentityProviderId { get; set; } = -1;
+        public string IdentityProviderName { get; set; }
+        public bool AllowPersonalAccounts { get; set; } = false;
+        public string[] AdminRoles { get; set; }
+    }
+}

--- a/SafeguardDevOpsService/Data/Spp/TrustedCertificate.cs
+++ b/SafeguardDevOpsService/Data/Spp/TrustedCertificate.cs
@@ -1,0 +1,9 @@
+﻿
+namespace OneIdentity.DevOps.Data.Spp
+{
+    public class TrustedCertificate
+    {
+        public string Base64CertificateData { get; set; }
+        public string Thumbprint { get; set; }
+    }
+}

--- a/SafeguardDevOpsService/Exceptions/DevOpsException.cs
+++ b/SafeguardDevOpsService/Exceptions/DevOpsException.cs
@@ -121,6 +121,10 @@ namespace OneIdentity.DevOps.Exceptions
         {
         }
 
+        public DevOpsException(string message, Exception ex) : base(message, ex)
+        {
+        }
+
         protected DevOpsException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             var responseMessage = new HttpResponseMessage();

--- a/SafeguardDevOpsService/Extensions/EnumExtensions.cs
+++ b/SafeguardDevOpsService/Extensions/EnumExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OneIdentity.DevOps.Extensions
+{
+    public static class EnumExtensions
+    {
+        public static string GetName(this Enum This)
+        {
+            return Enum.GetName(This.GetType(), This);
+        }
+    }
+    public class Enum<T> where T : struct, IConvertible
+    {
+        public static IEnumerable<T> Values
+        {
+            get
+            {
+                if (!typeof(T).IsEnum)
+                    throw new ArgumentException("T must be an enumerated type");
+
+                return Enum.GetValues(typeof(T)).Cast<T>();
+            }
+        }
+    }
+}

--- a/SafeguardDevOpsService/Logic/AuthorizedCache.cs
+++ b/SafeguardDevOpsService/Logic/AuthorizedCache.cs
@@ -38,7 +38,7 @@ namespace OneIdentity.DevOps.Logic
 
         public ManagementConnection Find(string sessionKey)
         {
-            if (_cache.ContainsKey(sessionKey))
+            if (sessionKey != null && _cache.ContainsKey(sessionKey))
             {
                 return _cache[sessionKey];
             }

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -9,6 +9,9 @@ namespace OneIdentity.DevOps.Logic
         void DeleteSafeguardData();
 
         bool ValidateLogin(string token, bool tokenOnly = false);
+        void InstallClientCertificate(ClientCertificatePfx certificatePfx);
+        ClientCertificate GetClientCertificate(string thumbPrint);
+        void RemoveClientCertificate(string thumbPrint);
 
         ManagementConnection GetConnection();
         ManagementConnection Connect(ManagementConnectionData connectionData);

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -11,7 +11,7 @@ namespace OneIdentity.DevOps.Logic
         void DeleteSafeguardData();
 
         bool ValidateLogin(string token, bool tokenOnly = false);
-        void InstallClientCertificate(ClientCertificatePfx certificatePfx);
+        void InstallClientCertificate(ClientCertificate certificatePfx);
         ClientCertificate GetClientCertificate();
         void RemoveClientCertificate();
         string GetClientCSR(int? size, string subjectName);
@@ -20,9 +20,7 @@ namespace OneIdentity.DevOps.Logic
         ManagementConnection Connect(ManagementConnectionData connectionData);
         void Disconnect();
 
-
-        // Delete ME - only used for developement
-        void CreateA2AUser();
+        void ConfigureDevOpsService();
 
     }
 }

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -1,4 +1,6 @@
-﻿using OneIdentity.DevOps.Data;
+﻿using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Authentication.OAuth.Claims;
+using OneIdentity.DevOps.Data;
 
 namespace OneIdentity.DevOps.Logic
 {
@@ -10,11 +12,17 @@ namespace OneIdentity.DevOps.Logic
 
         bool ValidateLogin(string token, bool tokenOnly = false);
         void InstallClientCertificate(ClientCertificatePfx certificatePfx);
-        ClientCertificate GetClientCertificate(string thumbPrint);
-        void RemoveClientCertificate(string thumbPrint);
+        ClientCertificate GetClientCertificate();
+        void RemoveClientCertificate();
+        string GetClientCSR(int? size, string subjectName);
 
         ManagementConnection GetConnection();
         ManagementConnection Connect(ManagementConnectionData connectionData);
         void Disconnect();
+
+
+        // Delete ME - only used for developement
+        void CreateA2AUser();
+
     }
 }

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -126,6 +127,27 @@ namespace OneIdentity.DevOps.Logic
             }
         }
 
+        private ISafeguardConnection Connect()
+        {
+            if (_connectionContext == null)
+            {
+                throw new DevOpsException("Not logged in");
+            }
+
+            try
+            {
+                return SafeguardDotNet.Safeguard.Connect(_configDb.SafeguardAddress, _connectionContext.AccessToken,
+                    _configDb.ApiVersion ?? DefaultApiVersion, _configDb.IgnoreSsl ?? false);
+
+            }
+            catch (SafeguardDotNetException ex)
+            {
+                var msg = $"Failed to connect to Safeguard at '{_configDb.SafeguardAddress}': {ex.Message}";
+                _logger.Error(msg);
+                throw new DevOpsException(msg, ex);
+            }
+        }
+
         private ISafeguardConnection ConnectWithAccessToken(string token)
         {
             if (_connectionContext != null)
@@ -133,27 +155,17 @@ namespace OneIdentity.DevOps.Logic
                 DisconnectWithAccessToken();
             }
 
-            try
-            {
-                if (string.IsNullOrEmpty(_configDb.SafeguardAddress))
-                    throw new DevOpsException("Missing safeguard appliance configuration.");
-                if (string.IsNullOrEmpty(token))
-                    throw new DevOpsException("Missing safeguard access token.");
+            if (string.IsNullOrEmpty(_configDb.SafeguardAddress))
+                throw new DevOpsException("Missing safeguard appliance configuration.");
+            if (string.IsNullOrEmpty(token))
+                throw new DevOpsException("Missing safeguard access token.");
 
-                _connectionContext = new ManagementConnection
-                {
-                    AccessToken = token.ToSecureString()
-                };
-
-                return SafeguardDotNet.Safeguard.Connect(_configDb.SafeguardAddress, _connectionContext.AccessToken,
-                    _configDb.ApiVersion ?? DefaultApiVersion, _configDb.IgnoreSsl ?? false);
-            }
-            catch (SafeguardDotNetException ex)
+            _connectionContext = new ManagementConnection
             {
-                var msg = $"Failed to connect to Safeguard at '{_configDb.SafeguardAddress}': {ex.Message}";
-                _logger.Error(msg);
-                throw new DevOpsException(msg);
-            }
+                AccessToken = token.ToSecureString()
+            };
+
+            return Connect();
         }
 
         private void ConnectWithAccessToken(ManagementConnectionData connectionData)
@@ -180,8 +192,8 @@ namespace OneIdentity.DevOps.Logic
                     ApplianceAddress = _configDb.SafeguardAddress,
                     IgnoreSsl = connectionData.IgnoreSsl || (_configDb.IgnoreSsl ?? false)
                 };
-                sg = SafeguardDotNet.Safeguard.Connect(availability.ApplianceAddress, _connectionContext.AccessToken,
-                    _configDb.ApiVersion ?? DefaultApiVersion, availability.IgnoreSsl);
+
+                sg = Connect();
                 _connectionContext.Appliance = GetSafeguardAvailability(sg, ref availability);
                 var meJson = sg.InvokeMethod(Service.Core, Method.Get, "Me");
                 var loggedInUser = JsonHelper.DeserializeObject<LoggedInUser>(meJson);
@@ -195,33 +207,6 @@ namespace OneIdentity.DevOps.Logic
                 var msg = $"Failed to connect to Safeguard at '{_configDb.SafeguardAddress}': {ex.Message}";
                 _logger.Error(msg);
                 throw new DevOpsException(msg);
-            }
-            finally
-            {
-                sg?.Dispose();
-            }
-        }
-
-        private string ExecuteCommand(Method method, string path, string body = null, Dictionary<string,string> parameters = null)
-        {
-            if (_connectionContext == null)
-            {
-                throw new DevOpsException("Not logged in");
-            }
-
-            ISafeguardConnection sg = null;
-            try
-            {
-                sg = SafeguardDotNet.Safeguard.Connect(_configDb.SafeguardAddress, _connectionContext.AccessToken,
-                    _configDb.ApiVersion ?? DefaultApiVersion, _configDb.IgnoreSsl ?? false);
-
-                return sg.InvokeMethod(Service.Core, method, path, body, parameters);
-            }
-            catch (SafeguardDotNetException ex)
-            {
-                var msg = $"Failed to execute command '{path}': {ex.Message}";
-                _logger.Error(msg);
-                throw new DevOpsException(msg, ex);
             }
             finally
             {
@@ -263,55 +248,173 @@ namespace OneIdentity.DevOps.Logic
             }
         }
 
-        private void CreateA2ACertificateUser()
+        private void CreateA2AUser(ISafeguardConnection sg)
         {
             string thumbprint = _configDb.UserCertificate?.Thumbprint;
 
-            if (thumbprint != null)
+            if (thumbprint == null)
+                throw new DevOpsException("Failed to create A2A user due to missing client certificate");
+
+            var a2aUser = GetA2AUser(sg);
+            if (a2aUser == null)
             {
-                var p = new Dictionary<string, string>();
-                p.Add("filter", $"UserName eq '{A2AUser.DevOpsUserName}'");
+                a2aUser = new A2AUser()
+                {
+                    PrimaryAuthenticationIdentity = thumbprint
+                };
 
-                var result = ExecuteCommand(Method.Get, "Users", null, p);
-                var foundUsers = JsonHelper.DeserializeObject<List<A2AUser>>(result);
-
-                var a2aUser = foundUsers.Count > 0 ? foundUsers.FirstOrDefault() : new A2AUser();
-                a2aUser.PrimaryAuthenticationIdentity = thumbprint;
                 var a2aUserStr = JsonHelper.SerializeObject(a2aUser);
-                var path = foundUsers.Count > 0 ? $"Users/{a2aUser.Id}" : "Users";
-
-                ExecuteCommand(foundUsers.Count > 0 ? Method.Put : Method.Post, path, a2aUserStr);
+                var result = sg.InvokeMethodFull(Service.Core, Method.Post, "Users", a2aUserStr);
+                if (result.StatusCode == HttpStatusCode.Created)
+                {
+                    a2aUser = JsonHelper.DeserializeObject<A2AUser>(result.Body);
+                    _configDb.A2aUserId = a2aUser.Id;
+                }
+            }
+            else
+            {
+                if (!a2aUser.PrimaryAuthenticationIdentity.Equals(thumbprint,
+                    StringComparison.InvariantCultureIgnoreCase))
+                {
+                    a2aUser.PrimaryAuthenticationIdentity = thumbprint;
+                    var a2aUserStr = JsonHelper.SerializeObject(a2aUser);
+                    sg.InvokeMethodFull(Service.Core, Method.Put, $"Users/{a2aUser.Id}", a2aUserStr);
+                }
             }
         }
 
-        private void AddTrustedCertificate()
+        private A2AUser GetA2AUser(ISafeguardConnection sg)
         {
-            string thumbprint = _configDb.UserCertificate?.Thumbprint;
+            FullResponse result;
+
+            // If we don't have a user Id then try to find the user by name
+            if (_configDb.A2aUserId == null)
+            {
+                var p = new Dictionary<string, string> {{"filter", $"UserName eq '{WellKnownData.DevOpsUserName}'"}};
+
+                result = sg.InvokeMethodFull(Service.Core, Method.Get, "Users", null, p);
+                if (result.StatusCode == HttpStatusCode.OK)
+                {
+                    var foundUsers = JsonHelper.DeserializeObject<List<A2AUser>>(result.Body);
+
+                    if (foundUsers.Count > 0)
+                    {
+                        var a2aUser = foundUsers.FirstOrDefault();
+                        _configDb.A2aUserId = a2aUser.Id;
+                        return a2aUser;
+                    }
+                }
+            }
+            else // Otherwise just get the user by id
+            {
+                try
+                {
+                    result = sg.InvokeMethodFull(Service.Core, Method.Get, $"Users/{_configDb.A2aUserId}");
+                    if (result.StatusCode == HttpStatusCode.OK)
+                    {
+                        return JsonHelper.DeserializeObject<A2AUser>(result.Body);
+                    }
+                }
+                catch { }
+
+                // Apparently the user id we have is wrong so get rid of it.
+                _configDb.A2aUserId = null;
+            }
+
+            return null;
+        }
+
+        private void AddTrustedCertificate(ISafeguardConnection sg)
+        {
+            var thumbprint = _configDb.UserCertificate?.Thumbprint;
 
             if (thumbprint != null)
             {
-                string result = null;
+                FullResponse result = null;
                 try
                 {
-                    result = ExecuteCommand(Method.Get, $"TrustedCertificates/{thumbprint}");
-                }
-                catch (Exception ex)
-                {
-                    var z = ex;
-                }
+                    result = sg.InvokeMethodFull(Service.Core, Method.Get, $"TrustedCertificates/{thumbprint}");
+                } catch { }
 
-                if (result == null)
+                if (result == null || result.StatusCode == HttpStatusCode.NotFound)
                 {
                     var certData = _configDb.UserCertificate.Export(X509ContentType.Cert);
                     var trustedCert = new TrustedCertificate()
                     {
                         Base64CertificateData = Convert.ToBase64String(certData)
                     };
-                    var trustedCertStr = JsonHelper.SerializeObject(trustedCert);
 
-                    ExecuteCommand(Method.Post, "TrustedCertificates", trustedCertStr);
+                    var trustedCertStr = JsonHelper.SerializeObject(trustedCert);
+                    sg.InvokeMethodFull(Service.Core, Method.Post, "TrustedCertificates", trustedCertStr);
                 }
             }
+        }
+
+        private void CreateA2ARegistration(ISafeguardConnection sg)
+        {
+            if (_configDb.A2aUserId == null)
+                throw new DevOpsException("Failed to create A2A registration due to missing A2A user");
+
+            var a2aRegistration = GetA2ARegistration(sg);
+            if (a2aRegistration == null)
+            {
+                var registration = new A2ARegistration()
+                {
+                    AppName = WellKnownData.DevOpsServiceName,
+                    CertificateUserId = _configDb.A2aUserId.Value,
+                    VisibleToCertificateUsers = true
+                };
+
+                var registrationStr = JsonHelper.SerializeObject(registration);
+                var result = sg.InvokeMethodFull(Service.Core, Method.Post, "A2ARegistrations", registrationStr);
+                if (result.StatusCode == HttpStatusCode.Created)
+                {
+                    registration = JsonHelper.DeserializeObject<A2ARegistration>(result.Body);
+                    _configDb.A2aRegistrationId = registration.Id;
+                }
+            }
+        }
+
+        private A2ARegistration GetA2ARegistration(ISafeguardConnection sg)
+        {
+            FullResponse result;
+
+            // If we don't have a registration Id then try to find the registration by name
+            if (_configDb.A2aRegistrationId == null)
+            {
+                var p = new Dictionary<string, string> {{"filter", $"AppName eq '{WellKnownData.DevOpsServiceName}'"}};
+
+                result = sg.InvokeMethodFull(Service.Core, Method.Get, "A2ARegistrations", null, p);
+                if (result.StatusCode == HttpStatusCode.OK)
+                {
+                    var foundRegistrations = JsonHelper.DeserializeObject<List<A2ARegistration>>(result.Body);
+
+                    if (foundRegistrations.Count > 0)
+                    {
+                        var registration = foundRegistrations.FirstOrDefault();
+                        _configDb.A2aRegistrationId = registration.Id;
+                        return registration;
+                    }
+                }
+            }
+            else // Otherwise just get the registration by id
+            {
+                try
+                {
+                    result = sg.InvokeMethodFull(Service.Core, Method.Get,
+                        $"A2ARegistrations/{_configDb.A2aRegistrationId}");
+                    if (result.StatusCode == HttpStatusCode.OK)
+                    {
+                        return JsonHelper.DeserializeObject<A2ARegistration>(result.Body);
+                    }
+                }
+                catch {}
+
+                // Apparently the registration id we have is wrong so get rid of it.
+                _configDb.A2aRegistrationId = null;
+            }
+
+            return null;
         }
 
         public bool ValidateLogin(string token, bool tokenOnly = false)
@@ -363,37 +466,36 @@ namespace OneIdentity.DevOps.Logic
             return null;
         }
 
-        public void InstallClientCertificate(ClientCertificatePfx certificate)
+        public void InstallClientCertificate(ClientCertificate certificate)
         {
-            using (var memoryStream = new MemoryStream())
+            var certificateBytes = Convert.FromBase64String(certificate.Base64CertificateData);
+            var cert = certificate.Passphrase == null ? new X509Certificate2(certificateBytes) : new X509Certificate2(certificateBytes, certificate.Passphrase);
+
+            if (cert.HasPrivateKey)
             {
-                certificate.file.OpenReadStream().CopyTo(memoryStream);
-                var cert = certificate.passphrase == null ? new X509Certificate2(memoryStream.ToArray()) : new X509Certificate2(memoryStream.ToArray(), certificate.passphrase);
-
-                if (cert.HasPrivateKey)
+                _configDb.UserCertificatePassphrase = certificate.Passphrase;
+                _configDb.UserCertificateBase64Data = certificate.Base64CertificateData;
+            }
+            else
+            {
+                try
                 {
-                    _configDb.UserCertificate = cert;
+                    using var rsa = RSA.Create();
+                    var privateKeyBytes = Convert.FromBase64String(_configDb.CsrPrivateKeyBase64Data);
+                    rsa.ImportRSAPrivateKey(privateKeyBytes, out _);
+
+                    using (X509Certificate2 pubOnly = cert)
+                    using (X509Certificate2 pubPrivEphemeral = pubOnly.CopyWithPrivateKey(rsa))
+                    {
+                        _configDb.UserCertificatePassphrase = null;
+                        _configDb.UserCertificateBase64Data = Convert.ToBase64String(pubPrivEphemeral.Export(X509ContentType.Pfx));
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    try
-                    {
-                        using var rsa = RSA.Create();
-                        var privateKeyBytes = Convert.FromBase64String(_configDb.CsrPrivateKeyBase64Data);
-                        rsa.ImportRSAPrivateKey(privateKeyBytes, out _);
-
-                        using (X509Certificate2 pubOnly = cert)
-                        using (X509Certificate2 pubPrivEphemeral = pubOnly.CopyWithPrivateKey(rsa))
-                        {
-                            _configDb.UserCertificateBase64Data = Convert.ToBase64String(pubPrivEphemeral.Export(X509ContentType.Pfx));
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        var msg = $"Failed to import the certificate: {ex.Message}";
-                        _logger.Error(msg);
-                        throw new DevOpsException(msg);
-                    }
+                    var msg = $"Failed to import the certificate: {ex.Message}";
+                    _logger.Error(msg);
+                    throw new DevOpsException(msg);
                 }
             }
         }
@@ -453,14 +555,15 @@ namespace OneIdentity.DevOps.Logic
             }
         }
 
-        //DELETE ME.  Just for Development
-        public void CreateA2AUser()
+        public void ConfigureDevOpsService()
         {
             if (_connectionContext == null)
                 throw new DevOpsException("Not logged in");
 
-            CreateA2ACertificateUser();
-            AddTrustedCertificate();
+            using var sg = Connect();
+            CreateA2AUser(sg);
+            AddTrustedCertificate(sg);
+            CreateA2ARegistration(sg);
         }
 
         public Safeguard GetSafeguardData()
@@ -492,10 +595,42 @@ namespace OneIdentity.DevOps.Logic
             _configDb.SafeguardAddress = null;
             _configDb.ApiVersion = null;
             _configDb.IgnoreSsl = null;
+            _configDb.A2aRegistrationId = null;
+            _configDb.A2aUserId = null;
+            _configDb.CsrPrivateKeyBase64Data = null;
+            _configDb.CsrBase64Data = null;
+            _configDb.UserCertificate = null;
+            _configDb.UserCertificateBase64Data = null;
+            _configDb.UserCertificatePassphrase = null;
+            _configDb.UserCertificateThumbprint = null;
+
+            //TODO: Need to remove the A2AUser, A2ARegistration and ClientCertificate from the Safeguard appliance.
         }
 
         public ManagementConnection GetConnection()
         {
+            _connectionContext.IdentityProviderName = null;
+            _connectionContext.UserName = null;
+            _connectionContext.AdminRoles = null;
+            _connectionContext.A2ARegistrationName = null;
+
+            using var sg = Connect();
+            var a2aUser = GetA2AUser(sg);
+            if (a2aUser != null)
+            {
+                _connectionContext.IdentityProviderName = a2aUser.IdentityProviderName;
+                _connectionContext.UserName = a2aUser.UserName;
+                _connectionContext.AdminRoles = a2aUser.AdminRoles;
+            }
+
+            _connectionContext.Appliance = GetSafeguardAppliance(sg);
+
+            var a2aRegistration = GetA2ARegistration(sg);
+            if (a2aRegistration != null)
+            {
+                _connectionContext.A2ARegistrationName = a2aRegistration.AppName;
+            }
+
             return _connectionContext;
         }
 

--- a/SafeguardDevOpsService/Logic/WellKnownData.cs
+++ b/SafeguardDevOpsService/Logic/WellKnownData.cs
@@ -6,6 +6,9 @@
         public const string PluginsName = "Plugins";
         public const string PluginInfoClassName = "PluginDescriptor";
 
+        public const string DevOpsServiceName = "SafeguardDevOpsService";
+        public const string DevOpsUserName = "SafeguardDevOpsUser";
+
         public const string DllExtension = ".dll";
         public const string DllPattern = "*.dll";
     }

--- a/SafeguardDevOpsService/SafeguardDevOpsService.csproj
+++ b/SafeguardDevOpsService/SafeguardDevOpsService.csproj
@@ -40,7 +40,6 @@
 
   <ItemGroup>
     <Folder Include="Attributes\" />
-    <Folder Include="Extensions\" />
     <Folder Include="Authentication\" />
   </ItemGroup>
 

--- a/SafeguardDevOpsService/SafeguardDevOpsService.csproj
+++ b/SafeguardDevOpsService/SafeguardDevOpsService.csproj
@@ -39,7 +39,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Attributes\" />
     <Folder Include="Authentication\" />
   </ItemGroup>
 


### PR DESCRIPTION
* Rework the API so that
/Safeguard - gets the current configuration, puts a new configuration or deletes the ConfigurationName
/Logon and /Logoff - logon and logoff the user given a token in the authorize header
/ClientCertificate - Gets the current certificate, posts a new signed certificate or pfx in base64, deletes the client certificate
/CSR - Gets a new CSR to be signed and posted back to the devops service

When the devops service is configure using PUT /Safeguard?configure=true, a new A2A user is created, a new A2A registration is created and the client certificate is added to Safeguard trusted certificates.  If any of these objects already exist in the target safeguard appliance, the objects are updated with any new values that are required to connect the devops service.

TODO:
- Map the accounts to the A2A RegistrationsTableName
- Map the plugins to the accounts.
