### PR TITLE
Clean up the API and make the service HTTPS only

### DIFF
--- a/SafeguardDevOpsService/Attributes/SafeguardAuthorizationBaseAttribute.cs
+++ b/SafeguardDevOpsService/Attributes/SafeguardAuthorizationBaseAttribute.cs
@@ -13,13 +13,13 @@ namespace OneIdentity.DevOps.Attributes
         {
             var authHeader = context.HttpContext.Request.Headers.FirstOrDefault(c => c.Key == "Authorization");
             var sppToken = authHeader.Value.ToString();
-            if (!sppToken.StartsWith("spp-token:", StringComparison.InvariantCultureIgnoreCase))
+            if (!sppToken.StartsWith("spp-token ", StringComparison.InvariantCultureIgnoreCase))
             {
                 context.Result = new DevOpsUnauthorizedResult("Authorization Failed: Missing token");
                 return null;
             }
 
-            return sppToken.Split(":")[1];
+            return sppToken.Split(" ").LastOrDefault();
         }
 
         public string GetSessonKey(AuthorizationFilterContext context)

--- a/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
@@ -32,9 +32,14 @@ namespace OneIdentity.DevOps.ConfigDb
         string UserCertificateThumbprint { get; set; }
         string UserCertificateBase64Data { get; set; }
         string UserCertificatePassphrase { get; set; }
-        string CsrBase64Data { get; set; }
-        string CsrPrivateKeyBase64Data { get; set; }
+        string UserCsrBase64Data { get; set; }
+        string UserCsrPrivateKeyBase64Data { get; set; }
+        string WebSslCertificateBase64Data { get; set; }
+        string WebSslCertificatePassphrase { get; set; }
+        string WebSslCsrBase64Data { get; set; }
+        string WebSslCsrPrivateKeyBase64Data { get; set; }
 
         X509Certificate2 UserCertificate { get; }
+        X509Certificate2 WebSslCertificate { get; set; }
     }
 }

--- a/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
@@ -31,8 +31,12 @@ namespace OneIdentity.DevOps.ConfigDb
         private const string UserCertificateThumbprintKey = "UserCertThumbprint";
         private const string UserCertificateDataKey = "UserCertData";
         private const string UserCertificatePassphraseKey = "UserCertPassphrase";
-        private const string CsrDataKey = "CertificateSigningRequestData";
-        private const string CsrPrivateKeyDataKey = "CertificateSigningRequestPrivateKeyData";
+        private const string UserCsrDataKey = "UserCertificateSigningRequestData";
+        private const string UserCsrPrivateKeyDataKey = "UserCertificateSigningRequestPrivateKeyData";
+        private const string WebSslCertificateDataKey = "WebSslCertData";
+        private const string WebSslCertificatePassphraseKey = "WebSslCertPassphrase";
+        private const string WebSslCsrDataKey = "WebSslCertificateSigningRequestData";
+        private const string WebSslCsrPrivateKeyDataKey = "WebSslCertificateSigningRequestPrivateKeyData";
 
         public LiteDbConfigurationRepository()
         {
@@ -224,16 +228,40 @@ namespace OneIdentity.DevOps.ConfigDb
             set => SetSimpleSetting(UserCertificatePassphraseKey, value);
         }
 
-        public string CsrBase64Data
+        public string WebSslCertificateBase64Data
         {
-            get => GetSimpleSetting(CsrDataKey);
-            set => SetSimpleSetting(CsrDataKey, value);
+            get => GetSimpleSetting(WebSslCertificateDataKey);
+            set => SetSimpleSetting(WebSslCertificateDataKey, value);
         }
 
-        public string CsrPrivateKeyBase64Data
+        public string WebSslCertificatePassphrase
         {
-            get => GetSimpleSetting(CsrPrivateKeyDataKey);
-            set => SetSimpleSetting(CsrPrivateKeyDataKey, value);
+            get => GetSimpleSetting(WebSslCertificatePassphraseKey);
+            set => SetSimpleSetting(WebSslCertificatePassphraseKey, value);
+        }
+
+        public string UserCsrBase64Data
+        {
+            get => GetSimpleSetting(UserCsrDataKey);
+            set => SetSimpleSetting(UserCsrDataKey, value);
+        }
+
+        public string UserCsrPrivateKeyBase64Data
+        {
+            get => GetSimpleSetting(UserCsrPrivateKeyDataKey);
+            set => SetSimpleSetting(UserCsrPrivateKeyDataKey, value);
+        }
+
+        public string WebSslCsrBase64Data
+        {
+            get => GetSimpleSetting(WebSslCsrDataKey);
+            set => SetSimpleSetting(WebSslCsrDataKey, value);
+        }
+
+        public string WebSslCsrPrivateKeyBase64Data
+        {
+            get => GetSimpleSetting(WebSslCsrPrivateKeyDataKey);
+            set => SetSimpleSetting(WebSslCsrPrivateKeyDataKey, value);
         }
 
         public X509Certificate2 UserCertificate
@@ -282,21 +310,43 @@ namespace OneIdentity.DevOps.ConfigDb
 
                 return null;
             }
+        }
 
-            // set
-            // {
-            //     if (value != null)
-            //     {
-            //         UserCertificateBase64Data = string.IsNullOrEmpty(UserCertificatePassphrase) 
-            //             ? Convert.ToBase64String(value.Export(X509ContentType.Pfx)) 
-            //             : Convert.ToBase64String(value.Export(X509ContentType.Pfx, UserCertificatePassphrase));
-            //     }
-            //     else
-            //     {
-            //         UserCertificateBase64Data = null;
-            //         UserCertificateThumbprint = null;
-            //     }
-            // }
+        public X509Certificate2 WebSslCertificate
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(WebSslCertificateBase64Data))
+                {
+                    try
+                    {
+                        var bytes = Convert.FromBase64String(WebSslCertificateBase64Data);
+                        var cert = string.IsNullOrEmpty(WebSslCertificatePassphrase) 
+                            ? new X509Certificate2(bytes)
+                            : new X509Certificate2(bytes, WebSslCertificatePassphrase);
+                        return cert;
+                    }
+                    catch (Exception)
+                    {
+                        // TODO: log?
+                        // throw appropriate error?
+                    }
+                }
+
+                return null;
+            }
+
+            set
+            {
+                if (value != null)
+                {
+                    WebSslCertificateBase64Data = Convert.ToBase64String(value.Export(X509ContentType.Pfx));
+                }
+                else
+                {
+                    WebSslCertificateBase64Data = null;
+                }
+            }
         }
 
         public void Dispose()

--- a/SafeguardDevOpsService/Data/CertificateInfo.cs
+++ b/SafeguardDevOpsService/Data/CertificateInfo.cs
@@ -6,12 +6,12 @@ namespace OneIdentity.DevOps.Data
     /// <summary>
     /// Represents a certificate from a certificate store on the appliance
     /// </summary>
-    public class ClientCertificate
+    public class CertificateInfo
     {
         private DateTime _notBefore;
         private DateTime _notAfter;
 
-        public ClientCertificate()
+        public CertificateInfo()
         {
             Subject = "";
         }
@@ -64,7 +64,7 @@ namespace OneIdentity.DevOps.Data
         /// </summary>
         public string Passphrase { get; set; }
 
-        protected bool Equals(ClientCertificate other)
+        protected bool Equals(CertificateInfo other)
         {
             return string.Equals(Subject, other.Subject) && string.Equals(IssuedBy, other.IssuedBy) && NotBefore.Equals(other.NotBefore) && NotAfter.Equals(other.NotAfter) && string.Equals(Thumbprint, other.Thumbprint);
         }
@@ -74,7 +74,7 @@ namespace OneIdentity.DevOps.Data
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
-            return Equals((ClientCertificate) obj);
+            return Equals((CertificateInfo) obj);
         }
 
         public override int GetHashCode()

--- a/SafeguardDevOpsService/Data/CertificateType.cs
+++ b/SafeguardDevOpsService/Data/CertificateType.cs
@@ -1,0 +1,12 @@
+﻿
+namespace OneIdentity.DevOps.Data
+{
+    /// <summary>
+    /// Type of CSR to create
+    /// </summary>
+    public enum CertificateType
+    {
+        A2AClient,
+        WebSsh
+    }
+}

--- a/SafeguardDevOpsService/Data/Spp/A2ARetrievableAccount.cs
+++ b/SafeguardDevOpsService/Data/Spp/A2ARetrievableAccount.cs
@@ -16,5 +16,6 @@ namespace OneIdentity.DevOps.Data.Spp
         public string SystemDescription { get; set; }
         public string NetworkAddress { get; set; }
         public string DomainName { get; set; }
+        public string[] IpRestrictions { get; set; }
     }
 }

--- a/SafeguardDevOpsService/Logic/CertificateHelper.cs
+++ b/SafeguardDevOpsService/Logic/CertificateHelper.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Policy;
+using System.Text;
+using OneIdentity.DevOps.Data;
+using RestSharp.Extensions;
+
+namespace OneIdentity.DevOps.Logic
+{
+    class CertificateHelper
+    {
+        public static X509Certificate2 CreateDefaultSSLCertificate()
+        {
+            int certSize = 2048;
+            string certSubjectName = "CN=DevOpsServiceServerSSL";
+
+            using (RSA rsa = RSA.Create(certSize))
+            {
+                var certificateRequest = new CertificateRequest(certSubjectName, rsa,
+                    HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+                certificateRequest.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(false, false, 0, false));
+
+                certificateRequest.CertificateExtensions.Add(
+                    new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+                        true));
+
+                certificateRequest.CertificateExtensions.Add(
+                    new X509EnhancedKeyUsageExtension(
+                        new OidCollection
+                        {
+                            new Oid("1.3.6.1.5.5.7.3.1")
+                        },
+                        true));
+
+                certificateRequest.CertificateExtensions.Add(
+                    new X509SubjectKeyIdentifierExtension(certificateRequest.PublicKey, false));
+
+                return certificateRequest.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(10));
+            }
+        }
+
+        public static bool ValidateCertificate(X509Certificate2 sslCertificate, CertificateType certificateType)
+        {
+            if (sslCertificate == null)
+                return false;
+
+            var curDate = DateTime.UtcNow;
+            if (sslCertificate.HasPrivateKey == false ||
+                curDate < sslCertificate.NotBefore || curDate > sslCertificate.NotAfter || !HasUsage(sslCertificate, X509KeyUsageFlags.DigitalSignature))
+            {
+                return false;
+            }
+
+            switch (certificateType)
+            {
+                case CertificateType.A2AClient:
+                    if (!HasUsage(sslCertificate, X509KeyUsageFlags.KeyAgreement) || !HasEku(sslCertificate, "1.3.6.1.5.5.7.3.2"))
+                        return false;
+                    break;
+                case CertificateType.WebSsh:
+                    if (!HasUsage(sslCertificate, X509KeyUsageFlags.KeyEncipherment) || !HasEku(sslCertificate, "1.3.6.1.5.5.7.3.1"))
+                        return false;
+                    break;
+                default:
+                    return false;
+            }
+
+
+            return true;
+        }
+
+        private static bool HasUsage(X509Certificate2 cert, X509KeyUsageFlags flag)
+        {
+            if (cert.Version < 3) { return true; }
+
+            var extensions = cert.Extensions.OfType<X509KeyUsageExtension>().ToList();
+            if (!extensions.Any())
+            {
+                return flag != X509KeyUsageFlags.CrlSign && flag != X509KeyUsageFlags.KeyCertSign;
+            }
+            return (extensions[0].KeyUsages & flag) > 0;
+        }
+
+        private static bool HasEku(X509Certificate2 cert, string oid)
+        {
+            // A certificate with version less than 3 doesn't support extensions at all.  Therefore, applications won't use them to
+            // verify/enforce any restrictions that those extensions may be used for.  Essentially, the certificate can be used for
+            // anything.  For example, if a version 3 certificate is used for HTTPS/SSL and the certificate doesn't contain the
+            // "Server Authentication" Enhanced Key Usage, then the web browser will show an error page and not let the user proceed.
+            // But if a version 1 certificate is used for HTTPS/SSL, it will work just fine, as the browser doesn't validate/enforce
+            // any restrictions... because they don't exist.
+            if (cert.Version < 3) { return true; }
+
+            // RFC 5280, 4.2: https://tools.ietf.org/html/rfc5280#section-4.2
+            // "...A certificate MUST NOT include more than one instance of a particular extension."
+            var eku = cert.Extensions.OfType<X509EnhancedKeyUsageExtension>().FirstOrDefault();
+
+            // RFC 5280, 4.2.1.12: https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+            // If the extension is present, then the certificate MUST only be used for one of the purposes indicated. If multiple
+            // purposes are indicated the application need not recognize all purposes indicated, as long as the intended purpose
+            // is present. Certificate using applications MAY require that the extended key usage extension be present and that a
+            // particular purpose be indicated in order for the certificate to be acceptable to that application.
+            if (eku == null)
+            {
+                return true;
+            }
+
+            // Otherwise, the extension exists, so we must validate that it contains the we OID we need.
+            return eku.EnhancedKeyUsages[oid] != null;
+        }
+
+    }
+}

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -13,10 +13,12 @@ namespace OneIdentity.DevOps.Logic
         SafeguardConnection SetSafeguardData(SafeguardData safeguardData);
 
         bool ValidateLogin(string token, bool tokenOnly = false);
-        void InstallClientCertificate(ClientCertificate certificatePfx);
+
+        CertificateInfo GetCertificateInfo(CertificateType certificateType);
+        void InstallCertificate(CertificateInfo certificatePfx, CertificateType certificateType);
         void RemoveClientCertificate();
-        ClientCertificate GetClientCertificate();
-        string GetClientCSR(int? size, string subjectName);
+        void RemoveWebServerCertificate();
+        string GetCSR(int? size, string subjectName, CertificateType certificateType);
 
         IEnumerable<SppAccount> GetAvailableAccounts();
 
@@ -27,5 +29,7 @@ namespace OneIdentity.DevOps.Logic
 
         ServiceConfiguration GetDevOpsConfiguration();
         ServiceConfiguration ConfigureDevOpsService();
+        void DeleteDevOpsConfiguration();
+
     }
 }

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -283,46 +283,6 @@ namespace OneIdentity.DevOps.Logic
             return null;
         }
 
-        // private void AddTrustedCertificate(ISafeguardConnection sg)
-        // {
-        //     var thumbprint = _configDb.UserCertificate?.Thumbprint;
-        //
-        //     if (thumbprint != null)
-        //     {
-        //         FullResponse result = null;
-        //         try
-        //         {
-        //             result = sg.InvokeMethodFull(Service.Core, Method.Get, $"TrustedCertificates/{thumbprint}");
-        //         }
-        //         catch (Exception ex)
-        //         {
-        //             if (ex is SafeguardDotNetException && ((SafeguardDotNetException)ex).HttpStatusCode != HttpStatusCode.NotFound)
-        //             {
-        //                 throw LogAndThrow($"Failed to add the trusted certificate '{_configDb.SafeguardAddress}': {ex.Message}", ex);
-        //             }
-        //         }
-        //
-        //         if (result == null || result.StatusCode == HttpStatusCode.NotFound)
-        //         {
-        //             var certData = _configDb.UserCertificate.Export(X509ContentType.Cert);
-        //             var trustedCert = new TrustedCertificate()
-        //             {
-        //                 Base64CertificateData = Convert.ToBase64String(certData)
-        //             };
-        //
-        //             var trustedCertStr = JsonHelper.SerializeObject(trustedCert);
-        //             try
-        //             {
-        //                 sg.InvokeMethodFull(Service.Core, Method.Post, "TrustedCertificates", trustedCertStr);
-        //             }
-        //             catch (Exception ex)
-        //             {
-        //                 throw LogAndThrow($"Failed to add the trusted certificate '{_configDb.SafeguardAddress}': {ex.Message}", ex);
-        //             }
-        //         }
-        //     }
-        // }
-
         private void CreateA2ARegistration(ISafeguardConnection sg)
         {
             if (_configDb.A2aUserId == null)
@@ -705,7 +665,6 @@ namespace OneIdentity.DevOps.Logic
 
             using var sg = Connect();
             CreateA2AUser(sg);
-            //AddTrustedCertificate(sg);
             CreateA2ARegistration(sg);
 
             return GetDevOpsConfiguration();
@@ -828,21 +787,6 @@ namespace OneIdentity.DevOps.Logic
             {
                 _logger.Error($"Failed to delete the A2A certificate user {_configDb.A2aUserId} - {user?.UserName}: {ex.Message}");
             }
-
-            // try
-            // {
-            //     var thumbprint = _configDb.UserCertificate?.Thumbprint;
-            //     if (thumbprint != null)
-            //     {
-            //         sg.InvokeMethodFull(Service.Core, Method.Delete, $"TrustedCertificates/{thumbprint}");
-            //         RemoveClientCertificate();
-            //     }
-            // }
-            // catch (Exception ex)
-            // {
-            //     _logger.Error($"Failed to remove the A2A trusted certificate {_configDb.UserCertificate?.Thumbprint} - {user?.UserName}: {ex.Message}");
-            // }
-
         }
 
         public IEnumerable<A2ARetrievableAccount> GetA2ARetrievableAccounts()

--- a/SafeguardDevOpsService/Logic/WellKnownData.cs
+++ b/SafeguardDevOpsService/Logic/WellKnownData.cs
@@ -7,6 +7,9 @@
         public const string DevOpsServiceName = "SafeguardDevOpsService";
         public const string DevOpsUserName = "SafeguardDevOpsUser";
 
+        public const string DevOpsServiceClientCertificate = "CN=DevOpsServiceClientCertificate";
+        public const string DevOpsServiceWebSslCertificate = "CN=DevOpsServiceWebSslCertificate";
+
         public const string DllExtension = ".dll";
         public const string DllPattern = "*.dll";
     }

--- a/SafeguardDevOpsService/SafeguardDevOpsService.cs
+++ b/SafeguardDevOpsService/SafeguardDevOpsService.cs
@@ -4,6 +4,8 @@ using Autofac.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
 using OneIdentity.DevOps.Logic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using OneIdentity.DevOps.ConfigDb;
 
 
 namespace OneIdentity.DevOps
@@ -15,12 +17,25 @@ namespace OneIdentity.DevOps
 
         public SafeguardDevOpsService()
         {
+            var webSslCert = CheckDefaultCertificate();
+
+            if (webSslCert == null)
+            {
+                Serilog.Log.Logger.Error("Failed to find or change the default SSL certificate.");
+                System.Environment.Exit(1);
+            }
+
             _host = new WebHostBuilder()
-                .UseKestrel()
+                .UseKestrel(options =>
+                {
+                    options.ListenAnyIP(5001, listenOptions =>
+                        {
+                            listenOptions.UseHttps(webSslCert);
+                        });
+                })
                 .ConfigureServices(services => services.AddAutofac())
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>()
-                .UseUrls("http://*:5000")
                 .Build();
 
             // TODO: better way to start this service??
@@ -36,6 +51,20 @@ namespace OneIdentity.DevOps
         public void Stop()
         {
             _host.StopAsync().Wait();
+        }
+
+        private X509Certificate2 CheckDefaultCertificate()
+        {
+            using var db = new LiteDbConfigurationRepository();
+
+            X509Certificate2 webSslCert = db.WebSslCertificate;
+            if (webSslCert == null)
+            {
+                webSslCert = CertificateHelper.CreateDefaultSSLCertificate();
+                db.WebSslCertificate = webSslCert;
+            }
+
+            return webSslCert;
         }
     }
 }

--- a/SafeguardDevOpsService/Startup.cs
+++ b/SafeguardDevOpsService/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OneIdentity.DevOps.ConfigDb;
 using OneIdentity.DevOps.Logic;
@@ -110,7 +111,7 @@ namespace OneIdentity.DevOps
 
         }
 
-        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
             // Enable middleware to serve generated Swagger as a JSON endpoint.
             app.UseSwagger(c => { c.RouteTemplate = SwaggerRouteTemplate; });
@@ -122,6 +123,18 @@ namespace OneIdentity.DevOps
                 c.SwaggerEndpoint(OpenApiRelativeUrl, VersionApiName);
                 c.RoutePrefix = SwaggerRoutePrefix;
             });
+
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
 
             app.UseMvc();
         }


### PR DESCRIPTION
-Change spp-token: to spp-token<space>
-Get the list of available accounts from PolicyAccount
-Add an IP restriction to each a2a account
-Proxy the search functionality for Available account to PolicyAccount endpoint
-Don't automatically add the trusted certificate or delete the trusted CertificateHelper
-Make devops SSL only
 -Check the SSL cert on start up and create a default cert if necessary.
 -Create an API that will allow the user to upload a new cert from a CSR or a PFX