### PR TITLE
Pull the vault secret from Safeguard via A2A

### DIFF
--- a/DevOpsPluginCommon/ILoadablePlugin.cs
+++ b/DevOpsPluginCommon/ILoadablePlugin.cs
@@ -10,6 +10,7 @@ namespace OneIdentity.DevOps.Common
         string Description { get; }
         Dictionary<string, string> GetPluginInitialConfiguration();
         void SetPluginConfiguration(Dictionary<string, string> configuration);
+        void SetVaultCredential(string credential);
         bool SetPassword(string account, string password);
         void SetLogger(ILogger logger);
         void Unload();

--- a/ExternalPlugins/KubernetesSecrets/PluginDescriptor.cs
+++ b/ExternalPlugins/KubernetesSecrets/PluginDescriptor.cs
@@ -23,28 +23,34 @@ namespace OneIdentity.DevOps.KubernetesSecrets
 
         public Dictionary<string,string> GetPluginInitialConfiguration()
         {
-            return _configuration ?? (_configuration = new Dictionary<string, string>
+            return _configuration ??= new Dictionary<string, string>
             {
                 { ConfigFilePathName, "" },
                 { VaultNamespaceName, _defaultNamespace }
-            });
+            };
         }
 
         public void SetPluginConfiguration(Dictionary<string,string> configuration)
         {
-            KubernetesClientConfiguration config;
             if (configuration != null)
             {
                 _configuration = configuration;
-                config = configuration.ContainsKey(ConfigFilePathName) 
-                    ? KubernetesClientConfiguration.BuildConfigFromConfigFile(configuration[ConfigFilePathName]) 
+            }
+        }
+
+        public void SetVaultCredential(string credential)
+        {
+            KubernetesClientConfiguration config;
+            if (_configuration != null)
+            {
+                config = _configuration.ContainsKey(ConfigFilePathName) 
+                    ? KubernetesClientConfiguration.BuildConfigFromConfigFile(_configuration[ConfigFilePathName]) 
                     : KubernetesClientConfiguration.BuildDefaultConfig();
             }
             else
             {
                 config = KubernetesClientConfiguration.BuildDefaultConfig();
             }
-
 
             if (config != null)
             {

--- a/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
@@ -27,6 +27,7 @@ namespace OneIdentity.DevOps.ConfigDb
         bool? IgnoreSsl { get; set; }
         int? A2aUserId { get; set; }
         int? A2aRegistrationId { get; set; }
+        int? A2aVaultRegistrationId { get; set; }
         string SigningCertificate { get; set; }
 
         string UserCertificateThumbprint { get; set; }

--- a/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
@@ -28,6 +28,7 @@ namespace OneIdentity.DevOps.ConfigDb
         private const string IgnoreSslKey = "IgnoreSsl";
         private const string A2aUserIdKey = "A2aUserId";
         private const string A2aRegistrationIdKey = "A2aRegistrationId";
+        private const string A2aVaultRegistrationIdKey = "A2aVaultRegistrationId";
         private const string SigningCertificateKey = "SigningCertificate";
 
         private const string UserCertificateThumbprintKey = "UserCertThumbprint";
@@ -42,6 +43,7 @@ namespace OneIdentity.DevOps.ConfigDb
 
         public LiteDbConfigurationRepository()
         {
+            Directory.CreateDirectory(WellKnownData.AppDataPath);
             var dbPath = Path.Combine(WellKnownData.AppDataPath, DbFileName);
             Serilog.Log.Logger.Information($"Loading configuration database at {dbPath}.");
 
@@ -207,6 +209,22 @@ namespace OneIdentity.DevOps.ConfigDb
                 }
             }
             set => SetSimpleSetting(A2aRegistrationIdKey, value.ToString());
+        }
+
+        public int? A2aVaultRegistrationId
+        {
+            get
+            {
+                try
+                {
+                    return Int32.Parse(GetSimpleSetting(A2aVaultRegistrationIdKey));
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+            set => SetSimpleSetting(A2aVaultRegistrationIdKey, value.ToString());
         }
 
         public string SigningCertificate

--- a/SafeguardDevOpsService/Controllers/PluginsController.cs
+++ b/SafeguardDevOpsService/Controllers/PluginsController.cs
@@ -202,5 +202,40 @@ namespace OneIdentity.DevOps.Controllers
 
             return NoContent();
         }
+
+        /// <summary>
+        /// Get the vault account that is associated with a specific plugin.
+        /// </summary>
+        /// <param name="name">Name of the plugin.</param>
+        /// <response code="200">Success</response>
+        /// <response code="404">Not found</response>
+        [SafeguardSessionKeyAuthorization]
+        [UnhandledExceptionError]
+        [HttpGet("{name}/VaultAccount")]
+        public ActionResult<AssetAccount> GetPluginVaultAccount([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name)
+        {
+            var account = pluginsLogic.GetPluginVaultAccount(name);
+            if (account == null)
+                return NotFound();
+
+            return Ok(account);
+        }
+
+        /// <summary>
+        /// Associate an account with a plugin. The associated account will provide the vault with the authentication credential. (See /service/devops/Safeguard/AvailableAccounts)
+        /// </summary>
+        /// <param name="name">Name of plugin to update</param>
+        /// <param name="assetAccount">Account to associate with the vault.</param>
+        /// <response code="200">Success</response>
+        /// <response code="404">Not found</response>
+        [HttpPut("{name}/VaultAccount")]
+        public ActionResult<AssetAccount> PutPluginVaultAccount([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name, [FromBody] AssetAccount assetAccount)
+        {
+            var account = pluginsLogic.SavePluginVaultAccount(name, assetAccount);
+            if (account == null)
+                return NotFound();
+
+            return Ok(account);
+        }
     }
 }

--- a/SafeguardDevOpsService/Controllers/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/SafeguardController.cs
@@ -303,40 +303,44 @@ namespace OneIdentity.DevOps.Controllers
         /// <summary>
         /// Get the A2A registration that was created and used by the DevOps service.
         /// </summary>
+        /// <param name="registrationType">Type of registration.  Types: Account (default), Vault</param>
         /// <response code="200">Success</response>
         /// <response code="400">Bad Request</response>
         /// <response code="404">Not found</response>
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpGet("A2ARegistration")]
-        public ActionResult<A2ARegistration> GetA2ARegistration([FromServices] ISafeguardLogic safeguard)
+        public ActionResult<A2ARegistration> GetA2ARegistration([FromServices] ISafeguardLogic safeguard, [FromQuery] string registrationType = "Account")
         {
-            var registration = safeguard.GetA2ARegistration();
+            if (!Enum.TryParse(registrationType, true, out A2ARegistrationType rType))
+                return BadRequest("Invalid registration type");
+
+            var registration = safeguard.GetA2ARegistration(rType);
             if (registration == null)
                 return NotFound();
 
             return Ok(registration);
         }
 
-        /// <summary>
-        /// Delete the A2A registration that is being used by the DevOps service. To help prevent unintended removal of the A2A registration,
-        /// A2A user and trusted client certificate as well as removal of the account mappings, the confirm query param is required. 
-        /// </summary>
-        /// <param name="confirm">This query parameter must be set to "yes" if the caller intends to remove the A2A registration.</param>
-        /// <response code="200">Success</response>
-        /// <response code="404">Not found</response>
-        [SafeguardSessionKeyAuthorization]
-        [UnhandledExceptionError]
-        [HttpDelete("A2ARegistration")]
-        public ActionResult DeleteA2ARegistration([FromServices] ISafeguardLogic safeguard, [FromQuery] string confirm)
-        {
-            if (confirm == null || !confirm.Equals("yes", StringComparison.InvariantCultureIgnoreCase))
-                return BadRequest();
-
-            safeguard.DeleteA2ARegistration();
-
-            return NoContent();
-        }
+        // /// <summary>
+        // /// Delete the A2A registration that is being used by the DevOps service. To help prevent unintended removal of the A2A registration,
+        // /// A2A user and trusted client certificate as well as removal of the account mappings, the confirm query param is required. 
+        // /// </summary>
+        // /// <param name="confirm">This query parameter must be set to "yes" if the caller intends to remove the A2A registration.</param>
+        // /// <response code="200">Success</response>
+        // /// <response code="404">Not found</response>
+        // [SafeguardSessionKeyAuthorization]
+        // [UnhandledExceptionError]
+        // [HttpDelete("A2ARegistration")]
+        // public ActionResult DeleteA2ARegistration([FromServices] ISafeguardLogic safeguard, [FromQuery] string confirm)
+        // {
+        //     if (confirm == null || !confirm.Equals("yes", StringComparison.InvariantCultureIgnoreCase))
+        //         return BadRequest();
+        //
+        //     safeguard.DeleteA2ARegistration();
+        //
+        //     return NoContent();
+        // }
 
         /// <summary>
         /// Get a list of the retrievable accounts that are associated with the A2A registration that is being used by the DevOps service.
@@ -348,7 +352,7 @@ namespace OneIdentity.DevOps.Controllers
         [HttpGet("A2ARegistration/RetrievableAccounts")]
         public ActionResult<IEnumerable<A2ARetrievableAccount>> GetRetrievableAccounts([FromServices] ISafeguardLogic safeguard)
         {
-            var retrievableAccounts = safeguard.GetA2ARetrievableAccounts();
+            var retrievableAccounts = safeguard.GetA2ARetrievableAccounts(A2ARegistrationType.Account);
 
             return Ok(retrievableAccounts);
         }
@@ -363,7 +367,7 @@ namespace OneIdentity.DevOps.Controllers
         [HttpPost("A2ARegistration/RetrievableAccounts")]
         public ActionResult<IEnumerable<A2ARetrievableAccount>> AddRetrievableAccounts([FromServices] ISafeguardLogic safeguard, IEnumerable<SppAccount> accounts)
         {
-            var retrievableAccounts = safeguard.AddA2ARetrievableAccounts(accounts);
+            var retrievableAccounts = safeguard.AddA2ARetrievableAccounts(accounts, A2ARegistrationType.Account);
 
             return Ok(retrievableAccounts);
         }

--- a/SafeguardDevOpsService/Data/A2ARegistrationType.cs
+++ b/SafeguardDevOpsService/Data/A2ARegistrationType.cs
@@ -1,0 +1,19 @@
+﻿
+namespace OneIdentity.DevOps.Data
+{
+    /// <summary>
+    /// Type of A2A registration
+    /// </summary>
+    public enum A2ARegistrationType
+    {
+        /// <summary>
+        /// A2A account credentials registration
+        /// </summary>
+        Account,
+
+        /// <summary>
+        /// A2A vault credentials registration
+        /// </summary>
+        Vault
+    }
+}

--- a/SafeguardDevOpsService/Data/Plugin.cs
+++ b/SafeguardDevOpsService/Data/Plugin.cs
@@ -24,5 +24,9 @@ namespace OneIdentity.DevOps.Data
         /// </summary>
         public string Base64PluginData { get; set; }
 
+        /// <summary>
+        /// A2A registration vault account id
+        /// </summary>
+        public int? VaultAccountId { get; set; }
     }
 }

--- a/SafeguardDevOpsService/Data/ServiceConfiguration.cs
+++ b/SafeguardDevOpsService/Data/ServiceConfiguration.cs
@@ -49,6 +49,10 @@ namespace OneIdentity.DevOps.Data
         /// </summary>
         public string A2ARegistrationName { get; set; }
         /// <summary>
+        /// A2A vault registration name
+        /// </summary>
+        public string A2AVaultRegistrationName { get; set; }
+        /// <summary>
         /// Thumb print
         /// </summary>
         public string Thumbprint { get; set; }

--- a/SafeguardDevOpsService/Data/Spp/AssetAccount.cs
+++ b/SafeguardDevOpsService/Data/Spp/AssetAccount.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Asset-Account information
     /// </summary>
-    public class SppAccount
+    public class AssetAccount
     {
         /// <summary>
         /// Account Id
@@ -28,22 +28,14 @@
         /// <summary>
         /// Asset Id
         /// </summary>
-        public int SystemId { get; set; }
+        public int AssetId { get; set; }
         /// <summary>
         /// Asset name
         /// </summary>
-        public string SystemName { get; set; }
+        public string AssetName { get; set; }
         /// <summary>
         /// Asset network address
         /// </summary>
-        public string SystemNetworkAddress { get; set; }
-        /// <summary>
-        /// Allow password request
-        /// </summary>
-        public bool AllowPasswordRequest { get; set; }
-        /// <summary>
-        /// Allow session request
-        /// </summary>
-        public bool AllowSessionRequest { get; set; }
+        public string AssetNetworkAddress { get; set; }
     }
 }

--- a/SafeguardDevOpsService/Logic/CertificateHelper.cs
+++ b/SafeguardDevOpsService/Logic/CertificateHelper.cs
@@ -74,16 +74,16 @@ namespace OneIdentity.DevOps.Logic
             switch (certificateType)
             {
                 case CertificateType.WebSsh:
-                    if (!HasUsage(sslCertificate, X509KeyUsageFlags.KeyAgreement) || !HasEku(sslCertificate, "1.3.6.1.5.5.7.3.1"))
+                    if (!HasUsage(sslCertificate, X509KeyUsageFlags.KeyEncipherment) || !HasEku(sslCertificate, "1.3.6.1.5.5.7.3.1"))
                     {
-                        logger.Error("Missing key agreement or enhanced key usage server authentication.");
+                        logger.Error("Missing key encipherment or enhanced key usage client authentication.");
                         return false;
                     }
                     break;
                 case CertificateType.A2AClient:
-                    if (!HasUsage(sslCertificate, X509KeyUsageFlags.KeyEncipherment) || !HasEku(sslCertificate, "1.3.6.1.5.5.7.3.2"))
+                    if (!HasUsage(sslCertificate, X509KeyUsageFlags.KeyAgreement) || !HasEku(sslCertificate, "1.3.6.1.5.5.7.3.2"))
                     {
-                        logger.Error("Missing key encipherment or enhanced key usage client authentication.");
+                        logger.Error("Missing key agreement or enhanced key usage server authentication.");
                         return false;
                     }
                     break;

--- a/SafeguardDevOpsService/Logic/IPluginManager.cs
+++ b/SafeguardDevOpsService/Logic/IPluginManager.cs
@@ -1,4 +1,6 @@
 ﻿using System.Security;
+using OneIdentity.DevOps.Data;
+
 #pragma warning disable 1591
 
 namespace OneIdentity.DevOps.Logic
@@ -7,7 +9,10 @@ namespace OneIdentity.DevOps.Logic
     {
         void Run();
         void SetConfigurationForPlugin(string name);
+        void SendPluginVaultCredentials(string plugin, string apiKey);
         bool SendPassword(string name, string accountName, SecureString password);
         bool IsLoadedPlugin(string name);
+
+        void RefreshPluginCredentials();
     }
 }

--- a/SafeguardDevOpsService/Logic/IPluginsLogic.cs
+++ b/SafeguardDevOpsService/Logic/IPluginsLogic.cs
@@ -21,6 +21,9 @@ namespace OneIdentity.DevOps.Logic
         void DeleteAccountMappings(string name);
         void DeleteAccountMappings();
 
+        A2ARetrievableAccount GetPluginVaultAccount(string name);
+        A2ARetrievableAccount SavePluginVaultAccount(string name, AssetAccount sppAccount);
+
         void RestartService();
     }
 }

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -14,6 +14,7 @@ namespace OneIdentity.DevOps.Logic
         SafeguardConnection GetSafeguardConnection();
         SafeguardConnection SetSafeguardData(string token, SafeguardData safeguardData);
 
+        bool IsLoggedIn();
         bool ValidateLogin(string token, bool tokenOnly = false);
 
         CertificateInfo GetCertificateInfo(CertificateType certificateType);
@@ -23,11 +24,14 @@ namespace OneIdentity.DevOps.Logic
         string GetCSR(int? size, string subjectName, CertificateType certificateType);
 
         IEnumerable<SppAccount> GetAvailableAccounts();
+        AssetAccount GetAccount(int id);
 
-        A2ARegistration GetA2ARegistration();
-        void DeleteA2ARegistration();
-        IEnumerable<A2ARetrievableAccount> GetA2ARetrievableAccounts();
-        IEnumerable<A2ARetrievableAccount> AddA2ARetrievableAccounts(IEnumerable<SppAccount> accounts);
+        A2ARegistration GetA2ARegistration(A2ARegistrationType registrationType);
+        // void DeleteA2ARegistration();
+        A2ARetrievableAccount GetA2ARetrievableAccount(int id, A2ARegistrationType registrationType);
+        void DeleteA2ARetrievableAccount(int id, A2ARegistrationType registrationType);
+        IEnumerable<A2ARetrievableAccount> GetA2ARetrievableAccounts(A2ARegistrationType registrationType);
+        IEnumerable<A2ARetrievableAccount> AddA2ARetrievableAccounts(IEnumerable<SppAccount> accounts, A2ARegistrationType registrationType);
 
         ServiceConfiguration GetDevOpsConfiguration();
         ServiceConfiguration ConfigureDevOpsService();

--- a/SafeguardDevOpsService/Logic/MonitoringLogic.cs
+++ b/SafeguardDevOpsService/Logic/MonitoringLogic.cs
@@ -64,6 +64,8 @@ namespace OneIdentity.DevOps.Logic
                 return;
             }
 
+            _pluginManager.RefreshPluginCredentials();
+
             // connect to Safeguard
             _a2AContext = Safeguard.A2A.GetContext(sppAddress, Convert.FromBase64String(userCertificate), passPhrase, apiVersion.Value, ignoreSsl.Value);
 

--- a/SafeguardDevOpsService/Logic/WellKnownData.cs
+++ b/SafeguardDevOpsService/Logic/WellKnownData.cs
@@ -15,6 +15,9 @@ namespace OneIdentity.DevOps.Logic
         public const string DevOpsServiceName = "SafeguardDevOpsService";
         public const string DevOpsUserName = "SafeguardDevOpsUser";
 
+        public const string DevOpsRegistrationName = DevOpsServiceName;
+        public const string DevOpsVaultRegistrationName = DevOpsRegistrationName + "VaultCredentials";
+
         public const string DevOpsServiceClientCertificate = "CN=DevOpsServiceClientCertificate";
         public const string DevOpsServiceWebSslCertificate = "CN=DevOpsServiceWebSslCertificate";
 
@@ -24,10 +27,12 @@ namespace OneIdentity.DevOps.Logic
 
         public const string PluginDirName = "ExternalPlugins";
         public const string PluginStageName = "PluginStaging";
+        public const string PluginVaultCredentialName = "VaultCredential";
 
         public static readonly string AppDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), WellKnownData.DevOpsServiceName);
-        public static readonly string PluginDirPath = Path.Combine(WellKnownData.AppDataPath, WellKnownData.PluginDirName);
-        public static readonly string PluginStageDirPath = Path.Combine(WellKnownData.AppDataPath, WellKnownData.PluginDirName, WellKnownData.PluginStageName);
+        public static readonly string AppDataPathExt = Path.Combine(@"\", DevOpsServiceName);
+        public static readonly string PluginDirPath = Path.Combine(AppDataPathExt, PluginDirName);
+        public static readonly string PluginStageDirPath = Path.Combine(AppDataPathExt, PluginDirName, PluginStageName);
 
         public static string GetSppToken(HttpContext context)
         {

--- a/SafeguardDevOpsService/Program.cs
+++ b/SafeguardDevOpsService/Program.cs
@@ -10,8 +10,8 @@ namespace OneIdentity.DevOps
     {
         private static void Main()
         {
-            Directory.CreateDirectory(WellKnownData.AppDataPath);
-            var logDirPath = Path.Combine(WellKnownData.AppDataPath, "SafeguardDevOpsService.log");
+            Directory.CreateDirectory(WellKnownData.AppDataPathExt);
+            var logDirPath = Path.Combine(WellKnownData.AppDataPathExt, "SafeguardDevOpsService.log");
 
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.File(logDirPath, 
@@ -34,7 +34,10 @@ namespace OneIdentity.DevOps
                 hostConfig.SetDisplayName("SafeguardDevOpsService");
                 hostConfig.SetServiceName("SafeguardDevOpsService");
                 hostConfig.SetDescription("Safeguard for Privileged Passwords DevOps integration service.");
-                hostConfig.EnableShutdown();
+                hostConfig.EnableServiceRecovery(recoveryOption =>
+                {
+                    recoveryOption.RestartService(0);
+                });
             });
         }
     }

--- a/SafeguardDevOpsService/SafeguardDevOpsService.csproj
+++ b/SafeguardDevOpsService/SafeguardDevOpsService.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="LiteDB" Version="5.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
-    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="6.6.0-dev-312" />
+    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="6.6.0" />
     <PackageReference Include="Serilog.Extensions.Autofac.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />

--- a/SafeguardDevOpsService/Startup.cs
+++ b/SafeguardDevOpsService/Startup.cs
@@ -99,10 +99,10 @@ namespace OneIdentity.DevOps
         public void ConfigureContainer(ContainerBuilder builder)
         {
             builder.Register(c => new LiteDbConfigurationRepository()).As<IConfigurationRepository>().SingleInstance();
-            builder.Register(c => new PluginManager(c.Resolve<IConfigurationRepository>())).As<IPluginManager>().SingleInstance();
             builder.Register(c => new SafeguardLogic(c.Resolve<IConfigurationRepository>())).As<ISafeguardLogic>().SingleInstance();
+            builder.Register(c => new PluginManager(c.Resolve<IConfigurationRepository>(), c.Resolve<ISafeguardLogic>())).As<IPluginManager>().SingleInstance();
             builder.Register(c => new PluginsLogic(c.Resolve<IConfigurationRepository>(), c.Resolve<IPluginManager>(), c.Resolve<ISafeguardLogic>())).As<IPluginsLogic>().SingleInstance();
-            builder.Register(c => new MonitoringLogic(c.Resolve<IConfigurationRepository>(), c.Resolve<IPluginManager>())).As<IMonitoringLogic >().SingleInstance();
+            builder.Register(c => new MonitoringLogic(c.Resolve<IConfigurationRepository>(), c.Resolve<IPluginManager>())).As<IMonitoringLogic>().SingleInstance();
             //builder.RegisterType<ConfigurationLogic>().As<IConfigurationLogic>();
 
             //builder.RegisterType<SafeguardTokenAuthenticationProvider>().AsImplementedInterfaces().SingleInstance();

--- a/SafeguardDevOpsServiceWix/Product.wxs
+++ b/SafeguardDevOpsServiceWix/Product.wxs
@@ -59,11 +59,18 @@
                   Impersonate="yes"
                   Return="ignore"
                   ExeCommand='/c rmdir "[AppDataFolder]!(loc.ProductNameFolder)" /s /q' />
+    <CustomAction Id="CLEANUP_EXT_DATA_ON_UNINSTALL"
+                  Property="ExecuteCommand"
+                  Execute="immediate"
+                  Impersonate="yes"
+                  Return="ignore"
+                  ExeCommand='/c rmdir "\!(loc.ProductNameFolder)" /s /q' />
 
     <InstallExecuteSequence>
       <Custom Action="EXECUTE_STOP" After="CostFinalize">Installed</Custom>
       <Custom Action="EXECUTE_UNINSTALL" After="EXECUTE_STOP">Installed</Custom>
       <Custom Action="CLEANUP_DATA_ON_UNINSTALL" After="RemoveFiles">REMOVE="ALL"</Custom>
+      <Custom Action="CLEANUP_EXT_DATA_ON_UNINSTALL" After="CLEANUP_DATA_ON_UNINSTALL">REMOVE="ALL"</Custom>
       <Custom Action="EXECUTE_INSTALL" After="InstallFinalize">NOT Installed</Custom>
       <Custom Action="EXECUTE_START" After="EXECUTE_INSTALL">NOT Installed</Custom>
     </InstallExecuteSequence>


### PR DESCRIPTION
Modify the plugins and the plugin manager so that the third part vault credential is pulled from Safeguard via A2A.  The avoids the problem of exposing a vault secret in the devops database or code.