### PR TITLE
Support trusted certificates and SSL certificate validation between DevOps and Safeguard.

### DIFF
--- a/DevOpsPluginCommon/DevOpsPluginCommon.csproj
+++ b/DevOpsPluginCommon/DevOpsPluginCommon.csproj
@@ -5,21 +5,12 @@
     <RootNamespace>OneIdentity.DevOps.Common</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\</OutputPath>
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutputPath>$(SolutionDir)bin\$(Configuration)\</OutputPath>
     <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/ExternalPlugins/AzureKeyVault/AzureKeyVault.csproj
+++ b/ExternalPlugins/AzureKeyVault/AzureKeyVault.csproj
@@ -5,20 +5,11 @@
     <RootNamespace>OneIdentity.DevOps.AzureKeyVault</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\ExternalPlugins</OutputPath>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutputPath>$(SolutionDir)bin\$(Configuration)\ExternalPlugins</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\ExternalPlugins</OutputPath>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/ExternalPlugins/HashiCorpVault/HashiCorpVault.csproj
+++ b/ExternalPlugins/HashiCorpVault/HashiCorpVault.csproj
@@ -6,20 +6,11 @@
     <AssemblyName>HashiCorpVault</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\ExternalPlugins</OutputPath>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutputPath>$(SolutionDir)bin\$(Configuration)\ExternalPlugins</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\ExternalPlugins</OutputPath>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/ExternalPlugins/KubernetesSecrets/KubernetesSecrets.csproj
+++ b/ExternalPlugins/KubernetesSecrets/KubernetesSecrets.csproj
@@ -5,20 +5,11 @@
     <RootNamespace>OneIdentity.DevOps.KubernetesSecrets</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\ExternalPlugins</OutputPath>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutputPath>$(SolutionDir)bin\$(Configuration)\ExternalPlugins</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\ExternalPlugins</OutputPath>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
@@ -21,6 +21,12 @@ namespace OneIdentity.DevOps.ConfigDb
         void DeleteAccountMappingsByKey(string key);
         void DeleteAccountMappings();
 
+        IEnumerable<TrustedCertificate> GetAllTrustedCertificates();
+        TrustedCertificate GetTrustedCertificateByThumbPrint(string thumbprint);
+        TrustedCertificate SaveTrustedCertificate(TrustedCertificate trustedCertificate);
+        void DeleteTrustedCertificateByThumbPrint(string thumbprint);
+        void DeleteAllTrustedCertificates();
+        X509Chain GetTrustedChain();
 
         string SafeguardAddress { get; set; }
         int? ApiVersion { get; set; }

--- a/SafeguardDevOpsService/Data/CertificateInfo.cs
+++ b/SafeguardDevOpsService/Data/CertificateInfo.cs
@@ -1,5 +1,7 @@
 using System;
 using System.ComponentModel;
+using System.Security.Cryptography.X509Certificates;
+
 #pragma warning disable 1591
 
 namespace OneIdentity.DevOps.Data

--- a/SafeguardDevOpsService/Data/CertificateType.cs
+++ b/SafeguardDevOpsService/Data/CertificateType.cs
@@ -13,6 +13,10 @@ namespace OneIdentity.DevOps.Data
         /// <summary>
         /// Web Ssl certificate
         /// </summary>
-        WebSsh
+        WebSsh,
+        /// <summary>
+        /// Trusted certificate
+        /// </summary>
+        Trusted
     }
 }

--- a/SafeguardDevOpsService/Data/Spp/ServerCertifcate.cs
+++ b/SafeguardDevOpsService/Data/Spp/ServerCertifcate.cs
@@ -1,0 +1,25 @@
+﻿
+namespace OneIdentity.DevOps.Data.Spp
+{
+    /// <summary>
+    /// Represents a server certificate
+    /// </summary>
+    public class ServerCertificate
+    {
+        /// <summary>
+        /// The Subject of the certificate
+        /// </summary>
+        public string Subject { get; set; }
+
+        /// <summary>
+        /// The thumbprint of the certificate
+        /// </summary>
+        public string Thumbprint { get; set; }
+
+        /// <summary>
+        /// Base64 encoded certificate DER data
+        /// </summary>
+        public string Base64CertificateData { get; set; }
+
+    }
+}

--- a/SafeguardDevOpsService/Data/TrustedCertifcate.cs
+++ b/SafeguardDevOpsService/Data/TrustedCertifcate.cs
@@ -1,0 +1,50 @@
+﻿
+using System;
+using System.Security.Cryptography.X509Certificates;
+using LiteDB;
+
+namespace OneIdentity.DevOps.Data
+{
+    /// <summary>
+    /// Represents a trusted certificate
+    /// </summary>
+    public class TrustedCertificate
+    {
+        /// <summary>
+        /// Certificate thumbprint
+        /// </summary>
+        [BsonId]
+        public string Thumbprint { get; set; }
+
+        /// <summary>
+        /// Base64 representation of the certificate
+        /// </summary>
+        public string Base64CertificateData { get; set; }
+
+        /// <summary>
+        /// Get the certificate information
+        /// </summary>
+        public CertificateInfo GetCertificateInfo()
+        {
+            var cert = GetCertificate();
+            return new CertificateInfo()
+            {
+                IssuedBy = cert.Issuer,
+                NotAfter = cert.NotAfter,
+                NotBefore = cert.NotBefore,
+                Subject = cert.Subject,
+                Thumbprint = cert.Thumbprint,
+            };
+        }
+
+        /// <summary>
+        /// Get the certificate
+        /// </summary>
+        public X509Certificate2 GetCertificate()
+        {
+            var certificateBytes = Convert.FromBase64String(Base64CertificateData);
+            return new X509Certificate2(certificateBytes);
+        }
+
+    }
+}

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -39,5 +39,11 @@ namespace OneIdentity.DevOps.Logic
 
         void RestartService();
 
+        IEnumerable<CertificateInfo> GetTrustedCertificates();
+        CertificateInfo GetTrustedCertificate(string thumbPrint);
+        CertificateInfo AddTrustedCertificate(CertificateInfo certificate);
+        void DeleteTrustedCertificate(string thumbPrint);
+        IEnumerable<CertificateInfo> ImportTrustedCertificates();
+        void DeleteAllTrustedCertificates();
     }
 }

--- a/SafeguardDevOpsService/SafeguardDevOpsService.csproj
+++ b/SafeguardDevOpsService/SafeguardDevOpsService.csproj
@@ -10,23 +10,13 @@
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\</OutputPath>
-    <DocumentationFile>bin\$(Configuration)\SafeguardDevOpsService.xml</DocumentationFile>
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutputPath>$(SolutionDir)bin\$(Configuration)\</OutputPath>
     <DocumentationFile>bin\$(Configuration)\SafeguardDevOpsService.xml</DocumentationFile>
     <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>$(SolutionDir)bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -38,7 +28,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="LiteDB" Version="5.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
-    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="6.6.0" />
+    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="6.7.0-dev-322" />
     <PackageReference Include="Serilog.Extensions.Autofac.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />


### PR DESCRIPTION
Support trusted certificate and Safeguard SSL certificate validation. New endpoints for managing trusted certificates.  Also added a custom SSL certificate validation callback function that is handed to SafeguardDotNet.