### PR TITLE
Make the GET devops/safeguard api anonymous

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The Safeguard recommended practice is to keep the less secure DevOps environment
 
 ## Component Description
 
-**Safeguard API** -- Safeguard has the A2A (Application to Application) REST API and the Core REST API (labeled Config in the diagram) that is used to configure the A2A service as well as other Safeguard services.  There are aksi open source SDKs for accessing these APIs from a .NET Standard 2.0 library.
+**Safeguard API** -- Safeguard has the A2A (Application to Application) REST API and the Core REST API (labeled Config in the diagram) that is used to configure the A2A service as well as other Safeguard services.  There are also open source SDKs for accessing these APIs from a .NET Standard 2.0 library.
 
 - Discover -- A2A registrations are visible to certificate users via the core API.
 - Monitor -- The A2A API includes a SignalR web socket connection that will give real-time updates for when passwords change (no polling).

--- a/SafeguardDevOpsService/Controllers/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/SafeguardController.cs
@@ -31,7 +31,6 @@ namespace OneIdentity.DevOps.Controllers
         /// Get the state of the Safeguard appliance that the DevOps service is currently using.
         /// </summary>
         /// <response code="200">Success</response>
-        [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpGet]
         public ActionResult<SafeguardConnection> GetSafeguard([FromServices] ISafeguardLogic safeguard)

--- a/SafeguardDevOpsService/Data/SafeguardConnection.cs
+++ b/SafeguardDevOpsService/Data/SafeguardConnection.cs
@@ -3,20 +3,8 @@
     /// <summary>
     /// Safeguard appliance connection information
     /// </summary>
-    public class SafeguardConnection
+    public class SafeguardConnection : SafeguardData
     {
-        /// <summary>
-        /// Safeguard appliance network address
-        /// </summary>
-        public string ApplianceAddress { get; set; }
-        /// <summary>
-        /// Should ignore Ssl validation
-        /// </summary>
-        public bool IgnoreSsl { get; set; }
-        /// <summary>
-        /// Api version
-        /// </summary>
-        public int ApiVersion { get; set; }
         /// <summary>
         /// Safeguard appliance Id
         /// </summary>

--- a/SafeguardDevOpsService/Data/SafeguardData.cs
+++ b/SafeguardDevOpsService/Data/SafeguardData.cs
@@ -6,9 +6,9 @@
     public class SafeguardData
     {
         /// <summary>
-        /// Network address
+        /// Safeguard appliance network address
         /// </summary>
-        public string NetworkAddress { get; set; }
+        public string ApplianceAddress { get; set; }
         /// <summary>
         /// Api version
         /// </summary>

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -753,8 +753,9 @@ namespace OneIdentity.DevOps.Logic
         public SafeguardConnection GetSafeguardConnection()
         {
             if (string.IsNullOrEmpty(_configDb.SafeguardAddress))
-                return null;
-            return ConnectAnonymous(_configDb.SafeguardAddress, _configDb.ApiVersion ?? DefaultApiVersion, _configDb.IgnoreSsl ?? false);
+                return new SafeguardConnection();
+
+            return ConnectAnonymous(_configDb.SafeguardAddress, _configDb.ApiVersion ?? DefaultApiVersion, _configDb.IgnoreSsl ?? true);
         }
 
         public SafeguardConnection SetSafeguardData(string token, SafeguardData safeguardData)
@@ -762,18 +763,18 @@ namespace OneIdentity.DevOps.Logic
             if (token == null)
                 throw new DevOpsException("Invalid authorization token.");
 
-            var safeguardConnection = ConnectAnonymous(safeguardData.NetworkAddress,
+            var safeguardConnection = ConnectAnonymous(safeguardData.ApplianceAddress,
                 safeguardData.ApiVersion ?? DefaultApiVersion, safeguardData.IgnoreSsl ?? false);
 
             if (safeguardConnection != null && FetchAndStoreSignatureCertificate(token, safeguardConnection))
             {
-                _configDb.SafeguardAddress = safeguardData.NetworkAddress;
+                _configDb.SafeguardAddress = safeguardData.ApplianceAddress;
                 _configDb.ApiVersion = safeguardData.ApiVersion ?? DefaultApiVersion;
                 _configDb.IgnoreSsl = safeguardData.IgnoreSsl ?? false;
                 return safeguardConnection;
             }
 
-            throw new DevOpsException($"Invalid authorization token or SPP appliance {safeguardData.NetworkAddress} is unavailable.");
+            throw new DevOpsException($"Invalid authorization token or SPP appliance {safeguardData.ApplianceAddress} is unavailable.");
         }
 
         public void DeleteDevOpsConfiguration()


### PR DESCRIPTION
Make the GET devops/safeguard api anonymous so that the user can tell of the service has been connected to an SPP yet and which one.