### PR TITLE
Implement an endpoint that just drops the configuration database

### DIFF
--- a/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
@@ -48,5 +48,7 @@ namespace OneIdentity.DevOps.ConfigDb
 
         X509Certificate2 UserCertificate { get; }
         X509Certificate2 WebSslCertificate { get; set; }
+
+        void DropDatabase();
     }
 }

--- a/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
@@ -56,18 +56,23 @@ namespace OneIdentity.DevOps.Controllers.V1
             return Ok(appliance);
         }
 
-        // /// <summary>
-        // /// Deletes the current Safeguard configuration so that none is in use with the DevOps service.
-        // /// </summary>
-        // /// <response code="204">Success</response>
-        // [UnhandledExceptionError]
-        // [HttpDelete]
-        // public ActionResult DeleteSafeguard([FromServices] ISafeguardLogic safeguard)
-        // {
-        //     safeguard.DeleteSafeguardData();
-        //     return NoContent();
-        //     // TODO: error handling?
-        // }
+        /// <summary>
+        /// Deletes the current Safeguard DevOps service configuration, drops the configuration database and restarts the service. This endpoint
+        /// does not clean up any of the DevOps service related elements in any previously connected Safeguard appliance. (see DELETE /service/devops/{version}/Configuration)
+        /// </summary>
+        /// <response code="204">Success</response>
+        [SafeguardSessionKeyAuthorization]
+        [UnhandledExceptionError]
+        [HttpDelete]
+        public ActionResult DeleteSafeguard([FromServices] ISafeguardLogic safeguard, [FromQuery] string confirm)
+        {
+            if (confirm == null || !confirm.Equals("yes", StringComparison.InvariantCultureIgnoreCase))
+                return BadRequest();
+
+            safeguard.DeleteSafeguardData();
+
+            return NoContent();
+        }
 
         /// <summary>
         /// Get the current DevOps service configuration.
@@ -108,7 +113,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         }
 
         /// <summary>
-        /// Delete the DevOps service configuration.  This endpoint includes removing all account mappings, removing the A2A registration, A2A user and trusted
+        /// Delete the DevOps service configuration and restarts the service.  This endpoint includes removing all account mappings, removing the A2A registration, A2A user and trusted
         /// certificate from Safeguard and removing all stored configuration in the DevOps service.
         /// </summary>
         /// <response code="204">No Content</response>

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -12,6 +12,7 @@ namespace OneIdentity.DevOps.Logic
         ISafeguardConnection Connect();
         SafeguardConnection GetSafeguardConnection();
         SafeguardConnection SetSafeguardData(string token, SafeguardData safeguardData);
+        void DeleteSafeguardData();
 
         bool IsLoggedIn();
         bool ValidateLogin(string token, bool tokenOnly = false);

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -777,22 +777,18 @@ namespace OneIdentity.DevOps.Logic
             throw new DevOpsException($"Invalid authorization token or SPP appliance {safeguardData.ApplianceAddress} is unavailable.");
         }
 
+        public void DeleteSafeguardData()
+        {
+            _configDb.DropDatabase();
+            RestartService();
+        }
+
         public void DeleteDevOpsConfiguration()
         {
             DeleteA2ARegistration(A2ARegistrationType.Account);
             DeleteA2ARegistration(A2ARegistrationType.Vault);
             RemoveClientCertificate();
-
-            _configDb.SafeguardAddress = null;
-            _configDb.ApiVersion = null;
-            _configDb.IgnoreSsl = null;
-            _configDb.A2aRegistrationId = null;
-            _configDb.A2aUserId = null;
-            _configDb.UserCsrPrivateKeyBase64Data = null;
-            _configDb.UserCsrBase64Data = null;
-            _configDb.UserCertificateBase64Data = null;
-            _configDb.UserCertificatePassphrase = null;
-            _configDb.UserCertificateThumbprint = null;
+            DeleteSafeguardData();
         }
 
         public void RestartService()


### PR DESCRIPTION
Implement an endpoint that just drops the configuration database and restarts.  Rework the endpoint that deletes the configuration so that it not only cleans up the SPP elements but also drops the database and restarts.