### PR TITLE
Add a restart after updating the web ssl certificate. 

### DIFF
--- a/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
@@ -331,10 +331,13 @@ namespace OneIdentity.DevOps.Controllers.V1
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpPost("WebServerCertificate")]
-        public ActionResult InstallWebServerCertificate([FromServices] ISafeguardLogic safeguard, CertificateInfo certInfo)
+        public ActionResult InstallWebServerCertificate([FromServices] ISafeguardLogic safeguard, [FromBody] CertificateInfo certInfo, [FromQuery] bool restart = true)
         {
             safeguard.InstallCertificate(certInfo, CertificateType.WebSsl);
             var certificate = safeguard.GetCertificateInfo(CertificateType.WebSsl);
+
+            if (restart)
+                safeguard.RestartService();
 
             return Ok(certificate);
         }
@@ -356,9 +359,12 @@ namespace OneIdentity.DevOps.Controllers.V1
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpDelete("WebServerCertificate")]
-        public ActionResult RemoveWebServerCertificate([FromServices] ISafeguardLogic safeguard)
+        public ActionResult RemoveWebServerCertificate([FromServices] ISafeguardLogic safeguard, [FromQuery] bool restart = true)
         {
             safeguard.RemoveWebServerCertificate();
+
+            if (restart)
+                safeguard.RestartService();
 
             return NoContent();
         }
@@ -385,13 +391,13 @@ namespace OneIdentity.DevOps.Controllers.V1
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpGet("CSR")]
-        public ActionResult<string> GetClientCsr([FromServices] ISafeguardLogic safeguard, [FromQuery] int? size,
-            [FromQuery] string subjectName, [FromQuery] string certType = "A2AClient")
+        public ActionResult<string> GetClientCsr([FromServices] ISafeguardLogic safeguard, [FromQuery] int? size, 
+            [FromQuery] string subjectName, [FromQuery] string sanDns, [FromQuery] string sanIp, [FromQuery] string certType = "A2AClient")
         {
             if (!Enum.TryParse(certType, true, out CertificateType cType))
                 return BadRequest("Invalid certificate type");
 
-            var csr = safeguard.GetCSR(size, subjectName, cType);
+            var csr = safeguard.GetCSR(size, subjectName, sanDns, sanIp, cType);
             return Ok(csr);
         }
 

--- a/SafeguardDevOpsService/Extensions/PemExtensions.cs
+++ b/SafeguardDevOpsService/Extensions/PemExtensions.cs
@@ -26,9 +26,9 @@ namespace OneIdentity.DevOps.Extensions
         {
             var b64String = Convert.ToBase64String(This.Export(X509ContentType.Cert), Base64FormattingOptions.None);
             var builder = new StringBuilder()
-                .AppendLine("-----BEGIN CERTIFICATE-----")
-                .AppendLine(AddPemLineBreaks(b64String))
-                .Append("-----END CERTIFICATE-----");
+                .Append("-----BEGIN CERTIFICATE-----\r\n")
+                .Append(AddPemLineBreaks(b64String))
+                .Append("\r\n-----END CERTIFICATE-----");
             return builder.ToString();
         }
     }

--- a/SafeguardDevOpsService/Extensions/PemExtensions.cs
+++ b/SafeguardDevOpsService/Extensions/PemExtensions.cs
@@ -26,9 +26,9 @@ namespace OneIdentity.DevOps.Extensions
         {
             var b64String = Convert.ToBase64String(This.Export(X509ContentType.Cert), Base64FormattingOptions.None);
             var builder = new StringBuilder()
-                .Append("-----BEGIN CERTIFICATE-----\r\n")
-                .Append(AddPemLineBreaks(b64String))
-                .Append("\r\n-----END CERTIFICATE-----");
+                .AppendLine("-----BEGIN CERTIFICATE-----")
+                .AppendLine(AddPemLineBreaks(b64String))
+                .Append("-----END CERTIFICATE-----");
             return builder.ToString();
         }
     }

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -21,7 +21,7 @@ namespace OneIdentity.DevOps.Logic
         void InstallCertificate(CertificateInfo certificatePfx, CertificateType certificateType);
         void RemoveClientCertificate();
         void RemoveWebServerCertificate();
-        string GetCSR(int? size, string subjectName, CertificateType certificateType);
+        string GetCSR(int? size, string subjectName, string sanDns, string sanIp, CertificateType certificateType);
 
         IEnumerable<SppAccount> GetAvailableAccounts();
         AssetAccount GetAccount(int id);

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -652,7 +652,7 @@ namespace OneIdentity.DevOps.Logic
             }
         }
 
-        public string GetCSR(int? size, string subjectName, CertificateType certificateType)
+        public string GetCSR(int? size, string subjectName, string sanDns, string sanIp, CertificateType certificateType)
         {
             var certSize = 2048;
             var certSubjectName = certificateType == CertificateType.A2AClient ?
@@ -716,6 +716,34 @@ namespace OneIdentity.DevOps.Logic
                 certificateRequest.CertificateExtensions.Add(
                     new X509SubjectKeyIdentifierExtension(certificateRequest.PublicKey, false));
 
+                var sanBuilder = new SubjectAlternativeNameBuilder();
+                if (sanIp != null)
+                {
+                    try
+                    {
+                        var addresses = sanIp.Split(',').ToList();
+                        addresses.ForEach(x => sanBuilder.AddIpAddress(IPAddress.Parse(x)));
+                    }
+                    catch (Exception ex)
+                    {
+                        LogAndThrow("Invalid SAN IP address list.", ex);
+                    }
+                }
+
+                if (sanDns != null)
+                {
+                    try
+                    {
+                        var dnsNames = sanDns.Split(',').ToList();
+                        dnsNames.ForEach(x => sanBuilder.AddDnsName(x.Trim()));
+                    }
+                    catch (Exception ex)
+                    {
+                        LogAndThrow("Invalid SAN DNS list.", ex);
+                    }
+                }
+                certificateRequest.CertificateExtensions.Add(sanBuilder.Build());
+
                 var csr = certificateRequest.CreateSigningRequest();
                 switch (certificateType)
                 {
@@ -738,9 +766,9 @@ namespace OneIdentity.DevOps.Logic
                 }
 
                 var builder = new StringBuilder();
-                builder.AppendLine("-----BEGIN CERTIFICATE REQUEST-----\r\n");
+                builder.AppendLine("-----BEGIN CERTIFICATE REQUEST-----");
                 builder.AppendLine(PemExtensions.AddPemLineBreaks(Convert.ToBase64String(csr)));
-                builder.AppendLine("\r\n-----END CERTIFICATE REQUEST-----");
+                builder.Append("-----END CERTIFICATE REQUEST-----");
 
                 return builder.ToString();
             }

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -766,9 +766,9 @@ namespace OneIdentity.DevOps.Logic
                 }
 
                 var builder = new StringBuilder();
-                builder.AppendLine("-----BEGIN CERTIFICATE REQUEST-----");
-                builder.AppendLine(PemExtensions.AddPemLineBreaks(Convert.ToBase64String(csr)));
-                builder.Append("-----END CERTIFICATE REQUEST-----");
+                builder.Append("-----BEGIN CERTIFICATE REQUEST-----\r\n");
+                builder.Append(PemExtensions.AddPemLineBreaks(Convert.ToBase64String(csr)));
+                builder.Append("\r\n-----END CERTIFICATE REQUEST-----");
 
                 return builder.ToString();
             }

--- a/SafeguardDevOpsService/SafeguardDevOpsService.cs
+++ b/SafeguardDevOpsService/SafeguardDevOpsService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Configuration;
 using OneIdentity.DevOps.ConfigDb;
+using OneIdentity.DevOps.Extensions;
 using Serilog;
 
 namespace OneIdentity.DevOps
@@ -27,6 +28,9 @@ namespace OneIdentity.DevOps
                 Log.Logger.Error("Failed to find or change the default SSL certificate.");
                 Environment.Exit(1);
             }
+
+            Log.Logger.Information($"Thumbprint for {webSslCert.Subject}: {webSslCert.Thumbprint}");
+            Log.Logger.Information(webSslCert.ToPemFormat());
 
             Log.Logger.Information($"Configuration file location: {Path.Combine(WellKnownData.ServiceDirPath, WellKnownData.AppSettings)}.json");
             var configuration = new ConfigurationBuilder()


### PR DESCRIPTION
 Allow the user to specify IP and DNS SANs and add those to the CSR.  Print out the web ssl certificate to the log at start up.