### PR TITLE
TFS 253326 [BUG] Configure TLS client certificate user in cmdlet wizard returns an error

### DIFF
--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -1085,9 +1085,9 @@ namespace OneIdentity.DevOps.Logic
             if ((registrationType == A2ARegistrationType.Account && _configDb.A2aRegistrationId == null) ||
                 (registrationType == A2ARegistrationType.Vault && _configDb.A2aVaultRegistrationId == null))
             {
-                var msg = "A2A registration not configured";
+                var msg = "A2A registration not configured. Skipping...";
                 _logger.Error(msg);
-                throw new DevOpsException(msg);
+                return;
             }
 
             using var sg = Connect();

--- a/powershell/src/init.psm1
+++ b/powershell/src/init.psm1
@@ -149,11 +149,11 @@ function Initialize-SgDevOps
         try
         {
             Write-Host -ForegroundColor Cyan "This will be your connection for the rest of the steps in the wizard."
-            Connect-SgDevOps -ServiceAddress $ServiceAddress -ServicePort $ServicePort -Gui:$Gui
+            Connect-SgDevOps -Insecure -ServiceAddress $ServiceAddress -ServicePort $ServicePort -Gui:$Gui
         }
         catch
         {
-            Connect-SgDevOps -ServiceAddress $ServiceAddress -ServicePort $ServicePort -Gui:$Gui -Insecure
+            Connect-SgDevOps -Insecure -ServiceAddress $ServiceAddress -ServicePort $ServicePort -Gui:$Gui -Insecure
             Write-Host -ForegroundColor Magenta "You are not using a trusted TLS server certificate in Secrets Broker."
             Write-Host -ForegroundColor Cyan "You can fix this problem now by uploading a certificate with a private key."
             Write-Host -ForegroundColor Cyan "Another option is to fix this later a CSR with New-SgDevOpsCsr and Install-SgDevOpsSslCertificate cmdlets."
@@ -180,7 +180,7 @@ function Initialize-SgDevOps
             if ($local:Success)
             {
                 Write-Host -ForegroundColor Yellow "Reconnecting to Secrets Broker using Safeguard user ..."
-                Connect-SgDevOps -ServiceAddress $ServiceAddress -ServicePort $ServicePort -Gui:$Gui
+                Connect-SgDevOps -Insecure -ServiceAddress $ServiceAddress -ServicePort $ServicePort -Gui:$Gui
             }
         }
         Write-Host ""


### PR DESCRIPTION
Don't throw an exception when clearing the configuration if A2A has not been configured.  Just skip it.  Add an insecure flag to all of the calls in the initialize-sgdevops cmdlet.  The initialize cmdlet should always assume insecure.