### PR TITLE
Specify TLS protocol version explicitly

### DIFF
--- a/powershell/src/safeguard-devops.psm1
+++ b/powershell/src/safeguard-devops.psm1
@@ -236,7 +236,10 @@ function Get-TlsCertificateFromEndpoint
 
         $local:SslStream = New-Object -TypeName System.Net.Security.SslStream -ArgumentList @($local:TcpStream, $true, $local:Callback)
         try {
-            $local:SslStream.AuthenticateAsClient('')
+            $local:AllowedProtocols = ([System.Security.Authentication.SslProtocols]::Tls11 `
+                                            -bor [System.Security.Authentication.SslProtocols]::Tls12 `
+                                            -bor [System.Security.Authentication.SslProtocols]::Tls13)
+            $local:SslStream.AuthenticateAsClient('', $null, $local:AllowedProtocols, $false)
             $local:Certificate = $local:SslStream.RemoteCertificate
         } finally {
             $local:SslStream.Dispose()


### PR DESCRIPTION
On older clients, the protocols are set to Default for
AuthenticateAsClient instead of None. This means that they are
hard-coded to SSL3 and TLS1 instead of something more reasonable
depending on the OS.  Explicitly setting them to 1.1, 1.2, and 1.3 makes
sure that the server side doesn't refuse to communicate