### PR TITLE
Add a flag to the appliance data to indicate that the UI intends to remove the configuration if the connected SPP appliance changes.

### DIFF
--- a/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
@@ -32,6 +32,7 @@ namespace OneIdentity.DevOps.ConfigDb
         int? ApiVersion { get; set; }
         string SvcId { get; }
         bool? IgnoreSsl { get; set; }
+        bool? PendingRemoval { get; set; }
         int? A2aUserId { get; set; }
         int? A2aRegistrationId { get; set; }
         int? A2aVaultRegistrationId { get; set; }

--- a/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
@@ -33,6 +33,7 @@ namespace OneIdentity.DevOps.ConfigDb
         private const string SafeguardAddressKey = "SafeguardAddress";
         private const string ApiVersionKey = "ApiVersion";
         private const string IgnoreSslKey = "IgnoreSsl";
+        private const string PendingRemovalKey = "PendingRemoval";
         private const string A2aUserIdKey = "A2aUserId";
         private const string A2aRegistrationIdKey = "A2aRegistrationId";
         private const string A2aVaultRegistrationIdKey = "A2aVaultRegistrationId";
@@ -346,6 +347,22 @@ namespace OneIdentity.DevOps.ConfigDb
                 }
             }
             set => SetSimpleSetting(IgnoreSslKey, value.ToString());
+        }
+
+        public bool? PendingRemoval
+        {
+            get
+            {
+                try
+                {
+                    return bool.Parse(GetSimpleSetting(PendingRemovalKey));
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+            set => SetSimpleSetting(PendingRemovalKey, value.ToString());
         }
 
         public int? A2aUserId

--- a/SafeguardDevOpsService/Data/SafeguardData.cs
+++ b/SafeguardDevOpsService/Data/SafeguardData.cs
@@ -17,5 +17,9 @@
         /// Should ignore Ssl verification
         /// </summary>
         public bool? IgnoreSsl { get; set; }
+        /// <summary>
+        /// Should the database be removed if connecting to a different appliance
+        /// </summary>
+        public bool? PendingRemoval { get; set; }
     }
 }

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -148,6 +148,7 @@ namespace OneIdentity.DevOps.Logic
                 {
                     ApplianceAddress = safeguardAddress,
                     IgnoreSsl = _configDb.IgnoreSsl ?? ignoreSsl,
+                    PendingRemoval = _configDb.PendingRemoval ?? false,
                     ApiVersion = apiVersion
                 };
         
@@ -523,7 +524,8 @@ namespace OneIdentity.DevOps.Logic
             {
                 ApiVersion = _configDb.ApiVersion ?? DefaultApiVersion,
                 ApplianceAddress = _configDb.SafeguardAddress,
-                IgnoreSsl = _configDb.IgnoreSsl ?? false
+                IgnoreSsl = _configDb.IgnoreSsl ?? false,
+                PendingRemoval = _configDb.PendingRemoval ?? false
             });
         }
 
@@ -818,6 +820,7 @@ namespace OneIdentity.DevOps.Logic
                 {
                     ApplianceAddress = _configDb.SafeguardAddress,
                     IgnoreSsl = _configDb.IgnoreSsl,
+                    PendingRemoval = _configDb.PendingRemoval,
                     ApiVersion = _configDb.ApiVersion ?? DefaultApiVersion
                 };
         
@@ -871,9 +874,17 @@ namespace OneIdentity.DevOps.Logic
 
             if (safeguardConnection != null && FetchAndStoreSignatureCertificate(token, safeguardConnection))
             {
+                // if the address is the same then set the PendingRemove to whatever the user specified. If the addresses
+                //  are different, then a change was just made and the new state for PendingRemoval should be false.
+                _configDb.PendingRemoval = _configDb.SafeguardAddress == safeguardData.ApplianceAddress ? safeguardData.PendingRemoval : false;
                 _configDb.SafeguardAddress = safeguardData.ApplianceAddress;
                 _configDb.ApiVersion = safeguardData.ApiVersion ?? DefaultApiVersion;
                 _configDb.IgnoreSsl = safeguardData.IgnoreSsl ?? false;
+
+                safeguardConnection.ApplianceAddress = _configDb.SafeguardAddress;
+                safeguardConnection.ApiVersion = _configDb.ApiVersion;
+                safeguardConnection.IgnoreSsl = _configDb.IgnoreSsl;
+                safeguardConnection.PendingRemoval = _configDb.PendingRemoval;
                 return safeguardConnection;
             }
 
@@ -1360,6 +1371,7 @@ namespace OneIdentity.DevOps.Logic
                 {
                     ApplianceAddress = _configDb.SafeguardAddress,
                     IgnoreSsl = _configDb.IgnoreSsl != null && _configDb.IgnoreSsl.Value,
+                    PendingRemoval = _configDb.PendingRemoval != null && _configDb.PendingRemoval.Value,
                     ApiVersion = _configDb.ApiVersion ?? DefaultApiVersion
                 });
 


### PR DESCRIPTION
This flag is for UI use only. The backend is just storing the value.