### PR TITLE
Rework the installer to fix the following:

### DIFF
--- a/SafeguardDevOpsServiceWix/Component-generated.wxs
+++ b/SafeguardDevOpsServiceWix/Component-generated.wxs
@@ -1216,8 +1216,8 @@
                     <Component Id="index.html" Guid="*">
                         <File Id="index.html" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\index.html" />
                     </Component>
-                    <Component Id="main.6021c22654dcdea013fa.js" Guid="*">
-                        <File Id="main.6021c22654dcdea013fa.js" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\main.6021c22654dcdea013fa.js" />
+                    <Component Id="main.133da131c1f414725eac.js" Guid="*">
+                        <File Id="main.133da131c1f414725eac.js" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\main.133da131c1f414725eac.js" />
                     </Component>
                     <Component Id="polyfills.a4021de53358bb0fec14.js" Guid="*">
                         <File Id="polyfills.a4021de53358bb0fec14.js" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\polyfills.a4021de53358bb0fec14.js" />
@@ -1228,19 +1228,10 @@
                     <Component Id="scripts.568694a568f45ab03c95.js" Guid="*">
                         <File Id="scripts.568694a568f45ab03c95.js" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\scripts.568694a568f45ab03c95.js" />
                     </Component>
-                    <Component Id="styles.9f838da0b1a98c31618e.css" Guid="*">
-                        <File Id="styles.9f838da0b1a98c31618e.css" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\styles.9f838da0b1a98c31618e.css" />
+                    <Component Id="styles.cac096e93acbab6a5816.css" Guid="*">
+                        <File Id="styles.cac096e93acbab6a5816.css" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\styles.cac096e93acbab6a5816.css" />
                     </Component>
                     <Directory Id="assets" Name="assets">
-                        <Component Id="busy_black.gif" Guid="*">
-                            <File Id="busy_black.gif" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\assets\busy-black.gif" />
-                        </Component>
-                        <Component Id="busy_login.gif" Guid="*">
-                            <File Id="busy_login.gif" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\assets\busy-login.gif" />
-                        </Component>
-                        <Component Id="busy_white_32.gif" Guid="*">
-                            <File Id="busy_white_32.gif" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\assets\busy-white-32.gif" />
-                        </Component>
                         <Component Id="SafeguardLogo.png" Guid="*">
                             <File Id="SafeguardLogo.png" KeyPath="yes" Source="$(var.SourceDir)\ClientApp\dist\assets\SafeguardLogo.png" />
                         </Component>
@@ -1655,14 +1646,11 @@
             <ComponentRef Id="accessTokenCheck.js" />
             <ComponentRef Id="favicon.ico" />
             <ComponentRef Id="index.html" />
-            <ComponentRef Id="main.6021c22654dcdea013fa.js" />
+            <ComponentRef Id="main.133da131c1f414725eac.js" />
             <ComponentRef Id="polyfills.a4021de53358bb0fec14.js" />
             <ComponentRef Id="runtime.e227d1a0e31cbccbf8ec.js" />
             <ComponentRef Id="scripts.568694a568f45ab03c95.js" />
-            <ComponentRef Id="styles.9f838da0b1a98c31618e.css" />
-            <ComponentRef Id="busy_black.gif" />
-            <ComponentRef Id="busy_login.gif" />
-            <ComponentRef Id="busy_white_32.gif" />
+            <ComponentRef Id="styles.cac096e93acbab6a5816.css" />
             <ComponentRef Id="SafeguardLogo.png" />
         </ComponentGroup>
     </Fragment>

--- a/SafeguardDevOpsServiceWix/Product.wxs
+++ b/SafeguardDevOpsServiceWix/Product.wxs
@@ -4,27 +4,20 @@
      xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
 
   <Product Id="*" Name="SafeguardDevOpsService" Language="1033" Version="!(bind.fileVersion.DevOpsPluginCommon.dll)" Manufacturer="!(loc.CompanyName)" UpgradeCode="8a0194a6-6aed-441c-8130-a81b96490bd7">
-		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
+		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" InstallPrivileges="elevated" />
 
     <MajorUpgrade AllowSameVersionUpgrades="yes" Schedule="afterInstallInitialize" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate EmbedCab="yes"  />
 
-    <Icon Id="safeguard.ico" SourceFile="$(var.ProjectDir)\..\SafeguardLogo.ico"/>
-
-    <Property Id="ARPPRODUCTICON">safeguard.icon</Property>
     <Property Id="ARPURLINFOABOUT">https://github.com/OneIdentity/SafeguardDevOpsService</Property>
-    <!--<Property Id="ARPCOMMENTS" Value="$(var.ProductCopyright)" />-->
     <Property Id="MSIUSEREALADMINDETECTION" Value="1" />
+    <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
     <SetProperty Id="_INSTALL"   After="FindRelatedProducts" Value="1"><![CDATA[Installed="" AND REMOVE="" AND UPGRADINGPRODUCTCODE=""]]></SetProperty>
     <SetProperty Id="_UNINSTALL" After="FindRelatedProducts" Value="1"><![CDATA[Installed<>"" AND REMOVE="ALL" AND UPGRADINGPRODUCTCODE=""]]></SetProperty>
     <SetProperty Id="_CHANGE"    After="FindRelatedProducts" Value="1"><![CDATA[Installed<>"" AND REINSTALL="" AND REMOVE=""]]></SetProperty>
     <SetProperty Id="_REPAIR"    After="FindRelatedProducts" Value="1"><![CDATA[Installed<>"" AND REINSTALL="ALL" AND UPGRADINGPRODUCTCODE=""]]></SetProperty>
     <SetProperty Id="_UPGRADE"   After="FindRelatedProducts" Value="1"><![CDATA[Installed<>"" AND REINSTALL="" AND UPGRADINGPRODUCTCODE<>""]]></SetProperty>
-
-    <Condition Message="Installation requires Administrator privileges">
-      <![CDATA[Privileged]]>
-    </Condition>
 
     <Condition Message="32 bit windows is not supported.">
       VersionNT64
@@ -40,45 +33,48 @@
 		</Feature>
 
     <CustomAction Id="EXECUTE_INSTALL"
-                  Execute="commit"
+                  Execute="deferred"
                   Impersonate="no"
-                  Return="check"
+                  HideTarget="no"
+                  Return="ignore"
                   FileKey="SafeguardDevOpsService.exe"
                   ExeCommand="install" />
     <CustomAction Id="EXECUTE_START"
-                  Execute="commit"
+                  Property="ExecuteCommand"
+                  Execute="deferred"
                   Impersonate="no"
-                  Return="check"
-                  FileKey="SafeguardDevOpsService.exe"
-                  ExeCommand="start" />
+                  Return="ignore"
+                  ExeCommand='/c sc start SafeguardDevOpsService /s /q' />
     <CustomAction Id="EXECUTE_STOP"
-                  Execute="immediate"
+                  Execute="deferred"
                   Impersonate="no"
+                  HideTarget="no"
                   Return="check"
                   FileKey="SafeguardDevOpsService.exe"
                   ExeCommand="stop" />
     <CustomAction Id="EXECUTE_UNINSTALL"
-                  Execute="immediate"
+                  Execute="deferred"
                   Impersonate="no"
+                  HideTarget="no"
                   Return="check"
                   FileKey="SafeguardDevOpsService.exe"
                   ExeCommand="uninstall" />
     <Property Id="ExecuteCommand">cmd.exe</Property>
     <CustomAction Id="CLEANUP_DATA_ON_UNINSTALL"
                   Property="ExecuteCommand"
-                  Execute="commit"
+                  Execute="deferred"
                   Impersonate="no"
                   Return="ignore"
                   ExeCommand='/c rmdir "[ProgramFiles64Folder]!(loc.ProductNameFolder)" /s /q' />
     <CustomAction Id="CLEANUP_EXT_DATA_ON_UNINSTALL"
                   Property="ExecuteCommand"
-                  Execute="commit"
+                  Execute="deferred"
                   Impersonate="no"
                   Return="ignore"
                   ExeCommand='/c rmdir "[CommonAppDataFolder]!(loc.ProductNameFolder)" /s /q' />
 
     <InstallExecuteSequence>
-      <Custom Action="EXECUTE_STOP" After="CostFinalize">NOT _INSTALL</Custom>
+      <Custom Action="EXECUTE_STOP" After="InstallInitialize">NOT _INSTALL</Custom>
       <Custom Action="EXECUTE_UNINSTALL" After="EXECUTE_STOP">NOT _INSTALL</Custom>
       <Custom Action="CLEANUP_DATA_ON_UNINSTALL" Before="InstallFinalize">_UNINSTALL</Custom>
       <Custom Action="CLEANUP_EXT_DATA_ON_UNINSTALL" After="CLEANUP_DATA_ON_UNINSTALL">_UNINSTALL</Custom>

--- a/SafeguardDevOpsServiceWix/SetupSafeguardDevOpsService.wixproj
+++ b/SafeguardDevOpsServiceWix/SetupSafeguardDevOpsService.wixproj
@@ -14,6 +14,8 @@
     <DefineConstants>Debug;SourceDir=bin\$(Configuration)\publish</DefineConstants>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <SuppressValidation>False</SuppressValidation>
+    <SuppressIces>ICE61;ICE63</SuppressIces>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
@@ -61,8 +63,8 @@
   </Target>
   <Target Name="BeforeBuild">
     <Exec Command="dotnet publish $(ProjectDir)\..\SafeguardDevOpsService\SafeguardDevOpsService.csproj -c $(Configuration) -o $(ProjectDir)bin\$(Configuration)\Publish --self-contained true -r win-x64" />
-    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /f &quot;$(CertificatePath)&quot;  /p &quot;$(CertificatePassword)&quot; &quot;$(ProjectDir)bin\$(Configuration)\Publish\SafeguardDevOpsService.dll&quot;"/>
-    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /f &quot;$(CertificatePath)&quot;  /p &quot;$(CertificatePassword)&quot; &quot;$(ProjectDir)bin\$(Configuration)\Publish\SafeguardDevOpsService.exe&quot;"/>
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /f &quot;$(CertificatePath)&quot;  /p &quot;$(CertificatePassword)&quot; &quot;$(ProjectDir)bin\$(Configuration)\Publish\SafeguardDevOpsService.dll&quot;" />
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /f &quot;$(CertificatePath)&quot;  /p &quot;$(CertificatePassword)&quot; &quot;$(ProjectDir)bin\$(Configuration)\Publish\SafeguardDevOpsService.exe&quot;" />
     <HeatDirectory SuppressAllWarnings="true" ToolPath="$(WixToolPath)" AutogenerateGuids="$(HarvestDirectoryAutogenerateGuids)" OutputFile="Component-generated.wxs" SuppressFragments="true" SuppressUniqueIds="true" Transforms="%(HarvestDirectory.Transforms)" Directory="$(ProjectDir)bin\$(Configuration)\Publish" ComponentGroupName="DevOps_CommonAssemblies" DirectoryRefId="INSTALLLOCATION" KeepEmptyDirectories="false" PreprocessorVariable="var.SourceDir" SuppressRootDirectory="true" SuppressRegistry="true">
     </HeatDirectory>
     <GetAssemblyIdentity AssemblyFiles="$(ProjectDir)bin\$(Configuration)\Publish\DevOpsPluginCommon.dll">
@@ -73,7 +75,7 @@
     </CreateProperty>
   </Target>
   <Target Name="AfterBuild">
-    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /f &quot;$(CertificatePath)&quot;  /p &quot;$(CertificatePassword)&quot; &quot;$(ProjectDir)bin\$(Configuration)\en-us\*.msi&quot;"/>
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /f &quot;$(CertificatePath)&quot;  /p &quot;$(CertificatePassword)&quot; &quot;$(ProjectDir)bin\$(Configuration)\en-us\*.msi&quot;" />
   </Target>
   <PropertyGroup>
     <PreBuildEvent />


### PR DESCRIPTION
- Don't require administrator privileges to start the installer.  The installer will elevate the privileges when needed.
- Fix or suppress the warnings. There are 2 warnings that are being suppressed but the we require that the settings that cause the warning to work the way we have it.
- Fix the logger failing to log the service after installing for the first time.
- Fix upgrade and uninstall issues.