### PR TITLE
Add a background maintenance service

### DIFF
--- a/SafeguardDevOpsService/Controllers/V1/PluginsController.cs
+++ b/SafeguardDevOpsService/Controllers/V1/PluginsController.cs
@@ -214,7 +214,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [HttpPost("{name}/TestConnection")]
         public ActionResult TestPluginConnection([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name)
         {
-            var success = pluginsLogic.TestPluginConnectionByName(name);
+            var success = pluginsLogic.TestPluginConnectionByName(null, name);
 
             if (!success)
             {
@@ -292,7 +292,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [HttpPut("{name}/Accounts")]
         public ActionResult<IEnumerable<AccountMapping>> AddAccountMappings([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name, IEnumerable<A2ARetrievableAccount> accounts)
         {
-            var accountMappings = pluginsLogic.SaveAccountMappings(name, accounts);
+            var accountMappings = pluginsLogic.SaveAccountMappings(null, name, accounts);
 
             return Ok(accountMappings);
         }
@@ -378,7 +378,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [HttpGet("{name}/VaultAccount")]
         public ActionResult<AssetAccount> GetPluginVaultAccount([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name)
         {
-            var account = pluginsLogic.GetPluginVaultAccount(name);
+            var account = pluginsLogic.GetPluginVaultAccount(null, name);
             if (account == null)
                 return NotFound();
 
@@ -407,7 +407,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [HttpPut("{name}/VaultAccount")]
         public ActionResult<AssetAccount> PutPluginVaultAccount([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name, [FromBody] AssetAccount assetAccount)
         {
-            var account = pluginsLogic.SavePluginVaultAccount(name, assetAccount);
+            var account = pluginsLogic.SavePluginVaultAccount(null, name, assetAccount);
 
             return Ok(account);
         }

--- a/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
@@ -124,7 +124,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [HttpGet("Configuration")]
         public ActionResult<ServiceConfiguration> GetDevOpsConfiguration([FromServices] ISafeguardLogic safeguard)
         {
-            var serviceConfiguration = safeguard.GetDevOpsConfiguration();
+            var serviceConfiguration = safeguard.GetDevOpsConfiguration(null);
 
             return Ok(serviceConfiguration);
         }
@@ -192,7 +192,7 @@ namespace OneIdentity.DevOps.Controllers.V1
             if (confirm == null || !confirm.Equals("yes", StringComparison.InvariantCultureIgnoreCase))
                 return BadRequest();
 
-            safeguard.DeleteDevOpsConfiguration();
+            safeguard.DeleteDevOpsConfiguration(null);
 
             return NoContent();
         }
@@ -219,8 +219,6 @@ namespace OneIdentity.DevOps.Controllers.V1
             var safeguardConnection = safeguard.GetSafeguardConnection();
             if (safeguardConnection == null)
                 return NotFound("No Safeguard has not been configured");
-
-            Task.Run( async () => await safeguard.StartAddOnBackgroundMaintenance(pluginsLogic));
 
             return Ok(safeguardConnection);
         }
@@ -467,7 +465,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         public ActionResult GetAvailableAccounts([FromServices] ISafeguardLogic safeguard, [FromQuery] string filter = null, 
             [FromQuery] int? page = null, [FromQuery] bool? count = null, [FromQuery] int? limit = null, [FromQuery] string orderby = null, [FromQuery] string q = null)
         {
-            var availableAccounts = safeguard.GetAvailableAccounts(filter, page, count, limit, orderby, q);
+            var availableAccounts = safeguard.GetAvailableAccounts(null, filter, page, count, limit, orderby, q);
 
             return Ok(availableAccounts);
         }
@@ -495,7 +493,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         public ActionResult GetAvailableA2ARegistrations([FromServices] ISafeguardLogic safeguard, [FromQuery] string filter = null, 
             [FromQuery] int? page = null, [FromQuery] bool? count = null, [FromQuery] int? limit = null, [FromQuery] string orderby = null, [FromQuery] string q = null)
         {
-            var availableRegistrations = safeguard.GetAvailableA2ARegistrations(filter, page, count, limit, orderby, q);
+            var availableRegistrations = safeguard.GetAvailableA2ARegistrations(null, filter, page, count, limit, orderby, q);
 
             return Ok(availableRegistrations);
         }
@@ -522,7 +520,7 @@ namespace OneIdentity.DevOps.Controllers.V1
             if (!Enum.TryParse(registrationType, true, out A2ARegistrationType rType))
                 return BadRequest("Invalid registration type");
 
-            var registration = safeguard.GetA2ARegistration(rType);
+            var registration = safeguard.GetA2ARegistration(null, rType);
             if (registration == null)
                 return NotFound();
 
@@ -553,7 +551,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         public ActionResult<A2ARegistration> SetA2ARegistration([FromServices] ISafeguardLogic safeguard, [FromServices] IMonitoringLogic monitoringLogic, 
             [FromServices] IPluginsLogic pluginsLogic, [FromRoute] int id, [FromQuery] string confirm)
         {
-            var registration = safeguard.SetA2ARegistration(monitoringLogic, pluginsLogic, id);
+            var registration = safeguard.SetA2ARegistration(null, monitoringLogic, pluginsLogic, id);
             if (registration == null)
                 return NotFound();
 
@@ -579,7 +577,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [HttpGet("A2ARegistration/RetrievableAccounts")]
         public ActionResult<IEnumerable<A2ARetrievableAccount>> GetRetrievableAccounts([FromServices] ISafeguardLogic safeguard)
         {
-            var retrievableAccounts = safeguard.GetA2ARetrievableAccounts(A2ARegistrationType.Account);
+            var retrievableAccounts = safeguard.GetA2ARetrievableAccounts(null, A2ARegistrationType.Account);
 
             return Ok(retrievableAccounts);
         }
@@ -604,7 +602,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [HttpGet("A2ARegistration/RetrievableAccounts/{accountId}")]
         public ActionResult<A2ARetrievableAccount> GetRetrievableAccountById([FromServices] ISafeguardLogic safeguard, [FromRoute] int accountId)
         {
-            var retrievableAccount = safeguard.GetA2ARetrievableAccountById(A2ARegistrationType.Account, accountId);
+            var retrievableAccount = safeguard.GetA2ARetrievableAccountById(null, A2ARegistrationType.Account, accountId);
             if (retrievableAccount == null)
                 return NotFound();
 
@@ -631,7 +629,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [HttpPut("A2ARegistration/RetrievableAccounts")]
         public ActionResult<IEnumerable<A2ARetrievableAccount>> AddRetrievableAccounts([FromServices] ISafeguardLogic safeguard, IEnumerable<SppAccount> accounts)
         {
-            var retrievableAccounts = safeguard.AddA2ARetrievableAccounts(accounts, A2ARegistrationType.Account);
+            var retrievableAccounts = safeguard.AddA2ARetrievableAccounts(null, accounts, A2ARegistrationType.Account);
 
             return Ok(retrievableAccounts);
         }
@@ -656,7 +654,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [HttpDelete("A2ARegistration/RetrievableAccounts")]
         public ActionResult RemoveRetrievableAccounts([FromServices] ISafeguardLogic safeguard, IEnumerable<A2ARetrievableAccount> accounts)
         {
-            safeguard.RemoveA2ARetrievableAccounts(accounts, A2ARegistrationType.Account);
+            safeguard.RemoveA2ARetrievableAccounts(null, accounts, A2ARegistrationType.Account);
 
             return NoContent();
         }
@@ -786,7 +784,7 @@ namespace OneIdentity.DevOps.Controllers.V1
 
             if (importFromSafeguard)
             {
-                trustedCertificates = safeguard.ImportTrustedCertificates();
+                trustedCertificates = safeguard.ImportTrustedCertificates(null);
             }
             else
             {
@@ -931,7 +929,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         /// </remarks>
         /// <param name="addonName">Name of the add-on to remove.</param>
         /// <param name="confirm">This query parameter must be set to "yes" if the caller intends to remove the add-on.</param>
-        /// <param name="restart">Restart Safeguard Secrets Broker for DevOps after plugin install.</param>
+        /// <param name="restart">Restart Safeguard Secrets Broker for DevOps after removing the add-on.</param>
         /// <response code="200">Success. Needing restart</response>
         /// <response code="204">Success</response>
         /// <response code="400">Bad request</response>

--- a/SafeguardDevOpsService/Data/Spp/DevOpsSecretsBrokerAccount.cs
+++ b/SafeguardDevOpsService/Data/Spp/DevOpsSecretsBrokerAccount.cs
@@ -83,6 +83,9 @@ namespace OneIdentity.DevOps.Data.Spp
         /// </summary>
         public string CreatedByUserDisplayName { get; set; }
 
+        /// <summary>
+        /// Convert to string.
+        /// </summary>
         public override string ToString()
         {
             return AccountName;

--- a/SafeguardDevOpsService/Logic/BackgroundMaintenanceLogic.cs
+++ b/SafeguardDevOpsService/Logic/BackgroundMaintenanceLogic.cs
@@ -1,0 +1,287 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using OneIdentity.DevOps.Common;
+using OneIdentity.DevOps.ConfigDb;
+using OneIdentity.DevOps.Data;
+using OneIdentity.DevOps.Data.Spp;
+using OneIdentity.DevOps.Exceptions;
+using OneIdentity.SafeguardDotNet;
+using OneIdentity.SafeguardDotNet.A2A;
+using A2ARetrievableAccount = OneIdentity.DevOps.Data.Spp.A2ARetrievableAccount;
+
+namespace OneIdentity.DevOps.Logic
+{
+    internal class BackgroundMaintenanceLogic : IHostedService, IDisposable
+    {
+        private readonly Serilog.ILogger _logger;
+        private readonly IConfigurationRepository _configDb;
+        private readonly ISafeguardLogic _safeguardLogic;
+        private readonly IPluginsLogic _pluginsLogic;
+
+        public BackgroundMaintenanceLogic(IConfigurationRepository configDb, ISafeguardLogic safeguardLogic, IPluginsLogic pluginsLogic)
+        {
+            _logger = Serilog.Log.Logger;
+            _configDb = configDb;
+            _safeguardLogic = safeguardLogic;
+            _pluginsLogic = pluginsLogic;
+        }
+
+        private ISafeguardConnection GetSgConnection()
+        {
+            var sppAddress = _configDb.SafeguardAddress;
+            var userCertificate = _configDb.UserCertificateBase64Data;
+            var passPhrase = _configDb.UserCertificatePassphrase?.ToSecureString();
+            var apiVersion = _configDb.ApiVersion ?? WellKnownData.DefaultApiVersion;
+            var ignoreSsl = _configDb.IgnoreSsl ?? true;
+
+            if (sppAddress != null && userCertificate != null)
+            {
+                try
+                {
+                    _logger.Debug("Connecting to Safeguard: {address}");
+
+                    var a2AContext = Safeguard.A2A.GetContext(sppAddress, Convert.FromBase64String(userCertificate), passPhrase, apiVersion, ignoreSsl);
+                    var connection = Safeguard.Connect(sppAddress, Convert.FromBase64String(userCertificate), passPhrase, apiVersion, ignoreSsl);
+
+                    return connection;
+                }
+                catch (SafeguardDotNetException ex)
+                {
+                    _logger.Error($"Failed to connect to Safeguard at '{sppAddress}': {ex.Message}", ex);
+                }
+            }
+
+            return null;
+        }
+
+        private ISafeguardA2AContext GetA2aContext()
+        {
+            var sppAddress = _configDb.SafeguardAddress;
+            var userCertificate = _configDb.UserCertificateBase64Data;
+            var passPhrase = _configDb.UserCertificatePassphrase?.ToSecureString();
+            var apiVersion = _configDb.ApiVersion ?? WellKnownData.DefaultApiVersion;
+            var ignoreSsl = _configDb.IgnoreSsl ?? true;
+
+            if (sppAddress != null && userCertificate != null)
+            {
+                try
+                {
+                    _logger.Debug("Connecting to Safeguard A2A context: {address}");
+
+                    var a2AContext = Safeguard.A2A.GetContext(sppAddress, Convert.FromBase64String(userCertificate), passPhrase, apiVersion, ignoreSsl);
+
+                    return a2AContext;
+                }
+                catch (SafeguardDotNetException ex)
+                {
+                    _logger.Error($"Failed to connect to Safeguard A2A context at '{sppAddress}': {ex.Message}", ex);
+                }
+            }
+
+            return null;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            Task.Run(async () => await StartAddOnBackgroundMaintenance(cancellationToken), cancellationToken);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+
+
+        public async Task StartAddOnBackgroundMaintenance(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var sgConnection = GetSgConnection();
+
+                    if (sgConnection != null)
+                    {
+                        CheckAndAddSecretsBrokerInstance(sgConnection);
+                        CheckAndPushAddOnCredentials(sgConnection);
+                        CheckAndConfigureAddonPlugins(sgConnection);
+                        CheckAndSyncVaultCredentials(sgConnection);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error($"[Background Maintenance] {ex.Message}");
+                }
+
+                await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+            }
+        }
+
+        private void CheckAndConfigureAddonPlugins(ISafeguardConnection sgConnection)
+        {
+            var addons = _configDb.GetAllAddons();
+            foreach (var addon in addons)
+            {
+                var plugin = _configDb.GetPluginByName(addon.Manifest.PluginName);
+                if (plugin != null && plugin.IsSystemOwned != addon.Manifest.IsPluginSystemOwned)
+                {
+                    plugin.IsSystemOwned = addon.Manifest.IsPluginSystemOwned;
+                    _configDb.SavePluginConfiguration(plugin);
+                }
+
+                if (!string.IsNullOrEmpty(addon.VaultAccountName) 
+                    && addon.VaultAccountId.HasValue 
+                    && addon.VaultAccountId > 0
+                    && !string.IsNullOrEmpty(addon.Manifest?.PluginName))
+                {
+                    plugin = _configDb.GetPluginByName(addon.Manifest.PluginName);
+                    if (plugin != null && plugin.VaultAccountId != addon.VaultAccountId)
+                    {
+                        plugin.VaultAccountId = addon.VaultAccountId;
+                        _pluginsLogic.SavePluginVaultAccount(sgConnection, plugin.Name, new AssetAccount(){Id = addon.VaultAccountId.Value});
+                    }
+                }
+            }
+        }
+
+        private void CheckAndPushAddOnCredentials(ISafeguardConnection sgConnection)
+        {
+            if (_safeguardLogic.DevOpsSecretsBroker == null)
+                return;
+
+            var addons = _configDb.GetAllAddons().ToList();
+            if (!addons.Any())
+                return;
+            
+            var secretsBrokerAccounts = _safeguardLogic.GetSecretsBrokerAccounts(sgConnection);
+            if (secretsBrokerAccounts != null)
+            {
+                foreach (var addon in addons)
+                {
+                    var accounts = new List<DevOpsSecretsBrokerAccount>();
+                    foreach (var credential in addon.VaultCredentials)
+                    {
+                        if (secretsBrokerAccounts.All(x => x.AccountName != credential.Key))
+                        {
+                            accounts.Add(new DevOpsSecretsBrokerAccount()
+                            {
+                                AccountId = 0,
+                                AccountName = credential.Key,
+                                Description = addon.Manifest.DisplayName + " account",
+                                AssetId = _safeguardLogic.DevOpsSecretsBroker.AssetId,
+                                Password = credential.Value
+                            });
+                        }
+                    }
+
+                    if (accounts.Any())
+                    {
+                        var secretsBrokerAccountsStr = JsonHelper.SerializeObject(accounts);
+                        try
+                        {
+                            var result = sgConnection.InvokeMethodFull(Service.Core, Method.Post,
+                                $"DevOps/SecretsBrokers/{_safeguardLogic.DevOpsSecretsBroker.Id}/Accounts/Add",
+                                secretsBrokerAccountsStr);
+                            if (result.StatusCode == HttpStatusCode.OK)
+                            {
+                                // Refresh the secrets broker account list after the additions
+                                secretsBrokerAccounts = _safeguardLogic.GetSecretsBrokerAccounts(sgConnection);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Error(
+                                $"Failed to sync the credentials for the Add-On {addon.Name}: {ex.Message}", ex);
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(addon.VaultAccountName))
+                    {
+                        var vaultAccount = secretsBrokerAccounts.FirstOrDefault(x => x.AccountName.StartsWith(addon.VaultAccountName));
+                        if (vaultAccount != null && addon.VaultAccountId != vaultAccount.AccountId)
+                        {
+                            addon.VaultAccountId = vaultAccount.AccountId;
+                            addon.VaultAccountName = vaultAccount.AccountName;
+                            addon.VaultAssetId = vaultAccount.AssetId;
+                            addon.VaultAssetName = vaultAccount.AssetName;
+                            _configDb.SaveAddon(addon);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void CheckAndAddSecretsBrokerInstance(ISafeguardConnection sgConnection)
+        {
+            _safeguardLogic.AddSecretsBrokerInstance(sgConnection);
+        }
+
+
+        private void CheckAndSyncVaultCredentials(ISafeguardConnection sgConnection)
+        {
+            var addons = _configDb.GetAllAddons().ToList();
+            if (!addons.Any())
+                return;
+
+            var a2aRegistration = _safeguardLogic.GetA2ARegistration(sgConnection, A2ARegistrationType.Vault);
+
+            var accounts = new List<A2ARetrievableAccount>();
+
+            var result = sgConnection.InvokeMethodFull(Service.Core, Method.Get, $"A2ARegistrations/{a2aRegistration.Id}/RetrievableAccounts");
+            if (result.StatusCode == HttpStatusCode.OK)
+            {
+                accounts = JsonHelper.DeserializeObject<List<A2ARetrievableAccount>>(result.Body);
+            }
+
+            if (accounts.Any())
+            {
+                using var a2aContext = GetA2aContext();
+                foreach (var account in accounts)
+                {
+                    string pp;
+                    try
+                    {
+                        var p = a2aContext.RetrievePassword(account.ApiKey.ToSecureString());
+                        pp = p.ToInsecureString();
+                        if (string.IsNullOrEmpty(pp))
+                            continue;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Information($"Failed to check the password for account {account.AccountName} ", ex);
+                        continue;
+                    }
+
+                    foreach (var addon in addons)
+                    {
+                        var addonAccount =
+                            addon.VaultCredentials.FirstOrDefault(x => account.AccountName.StartsWith(x.Key) && !pp.Equals(x.Value));
+                        if (!string.IsNullOrEmpty(addonAccount.Value))
+                        {
+                            result = sgConnection.InvokeMethodFull(Service.Core, Method.Put, $"AssetAccounts/{account.AccountId}/Password", addonAccount.Value);
+                            if (result.StatusCode != HttpStatusCode.OK)
+                            {
+                                _logger.Error($"Failed to sync the password for account {account.AccountName} ");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/SafeguardDevOpsService/Logic/IPluginManager.cs
+++ b/SafeguardDevOpsService/Logic/IPluginManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security;
+using OneIdentity.SafeguardDotNet;
 
 #pragma warning disable 1591
 
@@ -9,11 +10,11 @@ namespace OneIdentity.DevOps.Logic
         void Run();
         void SetConfigurationForPlugin(string name);
         void SendPluginVaultCredentials(string plugin, string apiKey);
-        bool TestPluginVaultConnection(string plugin);
+        bool TestPluginVaultConnection(ISafeguardConnection sgConnection, string plugin);
         bool SendPassword(string name, string assetName, string accountName, SecureString password);
         bool IsLoadedPlugin(string name);
         bool IsDisabledPlugin(string name);
 
-        void RefreshPluginCredentials();
+        void RefreshPluginCredentials(ISafeguardConnection sgConnection);
     }
 }

--- a/SafeguardDevOpsService/Logic/IPluginsLogic.cs
+++ b/SafeguardDevOpsService/Logic/IPluginsLogic.cs
@@ -2,6 +2,9 @@
 using Microsoft.AspNetCore.Http;
 using OneIdentity.DevOps.Data;
 using OneIdentity.DevOps.Data.Spp;
+using OneIdentity.SafeguardDotNet;
+using A2ARetrievableAccount = OneIdentity.DevOps.Data.Spp.A2ARetrievableAccount;
+
 #pragma warning disable 1591
 
 namespace OneIdentity.DevOps.Logic
@@ -18,18 +21,18 @@ namespace OneIdentity.DevOps.Logic
 
         IEnumerable<AccountMapping> GetAccountMappings(string name);
         AccountMapping GetAccountMappingById(string name, int accountId);
-        IEnumerable<AccountMapping> SaveAccountMappings(string name, IEnumerable<A2ARetrievableAccount> mappings);
+        IEnumerable<AccountMapping> SaveAccountMappings(ISafeguardConnection sgConnection, string name, IEnumerable<A2ARetrievableAccount> mappings);
         void DeleteAccountMappings(string name);
         void DeleteAccountMappings(string name, IEnumerable<AccountMapping> accounts);
         void DeleteAccountMappings();
 
-        A2ARetrievableAccount GetPluginVaultAccount(string name);
-        A2ARetrievableAccount SavePluginVaultAccount(string name, AssetAccount sppAccount);
+        A2ARetrievableAccount GetPluginVaultAccount(ISafeguardConnection sgConnection, string name);
+        A2ARetrievableAccount SavePluginVaultAccount(ISafeguardConnection sgConnection, string name, AssetAccount sppAccount);
         void RemovePluginVaultAccount(string name);
         void ClearMappedPluginVaultAccounts();
 
         void RestartService();
-        bool TestPluginConnectionByName(string name);
+        bool TestPluginConnectionByName(ISafeguardConnection sgConnection, string name);
         PluginState GetPluginDisabledState(string name);
         PluginState UpdatePluginDisabledState(string name, bool isDisabled);
     }

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using OneIdentity.DevOps.Data;
 using OneIdentity.DevOps.Data.Spp;
@@ -10,6 +11,8 @@ namespace OneIdentity.DevOps.Logic
 {
     public interface ISafeguardLogic
     {
+        DevOpsSecretsBroker DevOpsSecretsBroker { get; }
+
         ISafeguardConnection Connect();
         SafeguardDevOpsConnection GetAnonymousSafeguardConnection();
         SafeguardDevOpsConnection GetSafeguardConnection();
@@ -25,23 +28,25 @@ namespace OneIdentity.DevOps.Logic
         void RemoveWebServerCertificate();
         string GetCSR(int? size, string subjectName, string sanDns, string sanIp, CertificateType certificateType);
 
-        object GetAvailableAccounts(string filter, int? page, bool? count, int? limit, string orderby, string q);
-        AssetAccount GetAccount(int id);
+        object GetAvailableAccounts(ISafeguardConnection sgConnection, string filter, int? page, bool? count, int? limit, string orderby, string q);
+        AssetAccount GetAccount(ISafeguardConnection sgConnection, int id);
 
-        object GetAvailableA2ARegistrations(string filter, int? page, bool? count, int? limit, string @orderby, string q);
-        A2ARegistration GetA2ARegistration(A2ARegistrationType registrationType);
-        A2ARegistration SetA2ARegistration(IMonitoringLogic monitoringLogic, IPluginsLogic pluginsLogic, int id);
-        // void DeleteA2ARegistration();
-        A2ARetrievableAccount GetA2ARetrievableAccount(int id, A2ARegistrationType registrationType);
-        void DeleteA2ARetrievableAccount(int id, A2ARegistrationType registrationType);
-        IEnumerable<A2ARetrievableAccount> GetA2ARetrievableAccounts(A2ARegistrationType registrationType);
-        A2ARetrievableAccount GetA2ARetrievableAccountById(A2ARegistrationType registrationType, int accountId);
-        IEnumerable<A2ARetrievableAccount> AddA2ARetrievableAccounts(IEnumerable<SppAccount> accounts, A2ARegistrationType registrationType);
-        void RemoveA2ARetrievableAccounts(IEnumerable<A2ARetrievableAccount> accounts, A2ARegistrationType registrationType);
+        object GetAvailableA2ARegistrations(ISafeguardConnection sgConnection, string filter, int? page, bool? count, int? limit, string @orderby, string q);
+        A2ARegistration GetA2ARegistration(ISafeguardConnection sgConnection, A2ARegistrationType registrationType);
+        A2ARegistration SetA2ARegistration(ISafeguardConnection sgConnection, IMonitoringLogic monitoringLogic, IPluginsLogic pluginsLogic, int id);
+        A2ARetrievableAccount GetA2ARetrievableAccount(ISafeguardConnection sgConnection, int id, A2ARegistrationType registrationType);
+        void DeleteA2ARetrievableAccount(ISafeguardConnection sgConnection, int id, A2ARegistrationType registrationType);
+        IEnumerable<A2ARetrievableAccount> GetA2ARetrievableAccounts(ISafeguardConnection sgConnection, A2ARegistrationType registrationType);
+        A2ARetrievableAccount GetA2ARetrievableAccountById(ISafeguardConnection sgConnection, A2ARegistrationType registrationType, int accountId);
+        IEnumerable<A2ARetrievableAccount> AddA2ARetrievableAccounts(ISafeguardConnection sgConnection, IEnumerable<SppAccount> accounts, A2ARegistrationType registrationType);
+        void RemoveA2ARetrievableAccounts(ISafeguardConnection sgConnection, IEnumerable<A2ARetrievableAccount> accounts, A2ARegistrationType registrationType);
 
-        ServiceConfiguration GetDevOpsConfiguration();
+        List<DevOpsSecretsBrokerAccount> GetSecretsBrokerAccounts(ISafeguardConnection sg);
+        void AddSecretsBrokerInstance(ISafeguardConnection sgConnection);
+
+        ServiceConfiguration GetDevOpsConfiguration(ISafeguardConnection sgConnection);
         ServiceConfiguration ConfigureDevOpsService();
-        void DeleteDevOpsConfiguration();
+        void DeleteDevOpsConfiguration(ISafeguardConnection sgConnection);
 
         void RestartService();
 
@@ -49,9 +54,7 @@ namespace OneIdentity.DevOps.Logic
         CertificateInfo GetTrustedCertificate(string thumbPrint);
         CertificateInfo AddTrustedCertificate(CertificateInfo certificate);
         void DeleteTrustedCertificate(string thumbPrint);
-        IEnumerable<CertificateInfo> ImportTrustedCertificates();
+        IEnumerable<CertificateInfo> ImportTrustedCertificates(ISafeguardConnection sgConnection);
         void DeleteAllTrustedCertificates();
-
-        Task StartAddOnBackgroundMaintenance(IPluginsLogic pluginsLogic);
     }
 }

--- a/SafeguardDevOpsService/Logic/MonitoringLogic.cs
+++ b/SafeguardDevOpsService/Logic/MonitoringLogic.cs
@@ -100,7 +100,7 @@ namespace OneIdentity.DevOps.Logic
                 return;
             }
 
-            _pluginManager.RefreshPluginCredentials();
+            _pluginManager.RefreshPluginCredentials(null);
 
             // connect to Safeguard
             _a2AContext = (ignoreSsl == true) ? Safeguard.A2A.GetContext(sppAddress, Convert.FromBase64String(userCertificate), passPhrase, apiVersion.Value, true) : 

--- a/SafeguardDevOpsService/Logic/WellKnownData.cs
+++ b/SafeguardDevOpsService/Logic/WellKnownData.cs
@@ -10,6 +10,8 @@ namespace OneIdentity.DevOps.Logic
 {
     internal static class WellKnownData
     {
+        public const int DefaultApiVersion = 3;
+
         public const string AppSettings = "appsettings";
         public const string ServiceIdentifier = "svcid";
         public const string CredentialTarget = "SSBfDbgn";

--- a/SafeguardDevOpsService/Startup.cs
+++ b/SafeguardDevOpsService/Startup.cs
@@ -101,6 +101,7 @@ namespace OneIdentity.DevOps
             });
 
             services.AddHostedService<AddonManager>();
+            services.AddHostedService<BackgroundMaintenanceLogic>();
         }
 
         // This only gets called if your environment is Development. The

--- a/SafeguardDevOpsService/publishfordebug.ps1
+++ b/SafeguardDevOpsService/publishfordebug.ps1
@@ -1,0 +1,1 @@
+﻿dotnet publish C:\Projects\SafeguardDevOpsService\SafeguardDevOpsService\SafeguardDevOpsService.csproj -c Debug -o C:\Projects\SafeguardDevOpsService\SafeguardDevOpsService\bin\Debug\Publish --self-contained true -r win-x64


### PR DESCRIPTION
The backgroud service handles keeping all of the secrets broker data that should be push to SPP, in sync.  Switch to using the certificate user to sync data with SPP when an actual user is not logged.