### PR TITLE
Rework the devopsinstance

### DIFF
--- a/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
@@ -27,6 +27,8 @@ namespace OneIdentity.DevOps.ConfigDb
         int? A2aUserId { get; set; }
         int? A2aRegistrationId { get; set; }
         int? A2aVaultRegistrationId { get; set; }
+        int? AssetId { get; set; }
+        int? AssetPartitionId { get; set; }
         string SigningCertificate { get; set; }
         string LastKnownMonitorState { get; set; }
 

--- a/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
@@ -39,6 +39,8 @@ namespace OneIdentity.DevOps.ConfigDb
         private const string A2aUserIdKey = "A2aUserId";
         private const string A2aRegistrationIdKey = "A2aRegistrationId";
         private const string A2aVaultRegistrationIdKey = "A2aVaultRegistrationId";
+        private const string AssetIdKey = "AssetId";
+        private const string AssetPartitionIdKey = "AssetPartitionId";
         private const string SigningCertificateKey = "SigningCertificate";
         private const string LastKnownMonitorStateKey = "LastKnownMonitorState";
 
@@ -439,6 +441,39 @@ namespace OneIdentity.DevOps.ConfigDb
             }
             set => SetSimpleSetting(A2aVaultRegistrationIdKey, value.ToString());
         }
+
+        public int? AssetId
+        {
+            get
+            {
+                try
+                {
+                    return Int32.Parse(GetSimpleSetting(AssetIdKey));
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+            set => SetSimpleSetting(AssetIdKey, value.ToString());
+        }
+
+        public int? AssetPartitionId
+        {
+            get
+            {
+                try
+                {
+                    return Int32.Parse(GetSimpleSetting(AssetPartitionIdKey));
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+            set => SetSimpleSetting(AssetPartitionIdKey, value.ToString());
+        }
+
 
         public string LastKnownMonitorState
         {

--- a/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
@@ -70,6 +70,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         {
             var token = WellKnownData.GetSppToken(HttpContext);
             var appliance = safeguard.SetSafeguardData(token, safeguardData);
+            safeguard.AddSecretsBrokerInstance(null);
 
             return Ok(appliance);
         }
@@ -229,6 +230,8 @@ namespace OneIdentity.DevOps.Controllers.V1
             var safeguardConnection = safeguard.GetSafeguardConnection();
             if (safeguardConnection == null)
                 return NotFound("No Safeguard has not been configured");
+
+            safeguard.RetrieveDevOpsSecretsBrokerInstance(null);
 
             return Ok(safeguardConnection);
         }
@@ -907,8 +910,9 @@ namespace OneIdentity.DevOps.Controllers.V1
         ///
         /// (See POST /service/devops/{version}/Plugins/File to upload a plugin file using multipart-form-data)
         /// </remarks>
-        /// <param name="formFile">Zip compressed add-on file.</param>
+        /// <param name="addonInfo">Secrets Broker add-on containing the base64 encoded zip file.</param>
         /// <param name="restart">Restart Safeguard Secrets Broker for DevOps after plugin install.</param>
+        /// <param name="force">Force add-on to installed even if another with the same name already exists.</param>
         /// <response code="200">Success. Needing restart</response>
         /// <response code="204">Success</response>
         /// <response code="400">Bad request</response>
@@ -940,6 +944,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         /// </remarks>
         /// <param name="formFile">Zip compressed add-on file.</param>
         /// <param name="restart">Restart Safeguard Secrets Broker for DevOps after plugin install.</param>
+        /// <param name="force">Force add-on to installed even if another with the same name already exists.</param>
         /// <response code="200">Success. Needing restart</response>
         /// <response code="204">Success</response>
         /// <response code="400">Bad request</response>

--- a/SafeguardDevOpsService/Data/ServiceConfiguration.cs
+++ b/SafeguardDevOpsService/Data/ServiceConfiguration.cs
@@ -13,6 +13,11 @@ namespace OneIdentity.DevOps.Data
     {
         private SecureString _accessToken;
         private string _sessionKey = Guid.NewGuid().ToString();
+        private A2ARegistration _a2ARegistration;
+        private A2ARegistration _a2AVaultRegistration;
+        private A2AUser _a2AUser;
+        private Asset _asset;
+        private AssetPartition _assetPartition;
 
         /// <summary>
         /// Service is authenticated
@@ -32,34 +37,86 @@ namespace OneIdentity.DevOps.Data
             get => _accessToken;
             set => _accessToken = value.Copy();
         }
+
         /// <summary>
         /// Identity provider name
         /// </summary>
-        public string IdentityProviderName { get; set; }
+        public string IdentityProviderName => _a2AUser?.IdentityProviderName;
+
         /// <summary>
         /// User name
         /// </summary>
-        public string UserName { get; set; }
+        public string UserName => _a2AUser?.UserName;
+
         /// <summary>
         /// User display name
         /// </summary>
-        public string UserDisplayName { get; set; }
-        /// <summary>
-        /// Admin roles
-        /// </summary>
-        public string[] AdminRoles { get; set; }
-        /// <summary>
-        /// A2A registration name
-        /// </summary>
-        public string A2ARegistrationName { get; set; }
-        /// <summary>
-        /// A2A vault registration name
-        /// </summary>
-        public string A2AVaultRegistrationName { get; set; }
+        public string UserDisplayName => _a2AUser?.DisplayName;
+
         /// <summary>
         /// Thumb print
         /// </summary>
-        public string Thumbprint { get; set; }
+        public string Thumbprint => _a2AUser?.PrimaryAuthenticationIdentity;
+
+        /// <summary>
+        /// Admin roles
+        /// </summary>
+        public string[] AdminRoles => _a2AUser?.AdminRoles;
+
+        /// <summary>
+        /// A2A Certificate User
+        /// </summary>
+        public A2AUser A2AUser
+        {
+            get => _a2AUser; 
+            set => _a2AUser = value;
+        }
+
+        /// <summary>
+        /// A2A registration name
+        /// </summary>
+        public string A2ARegistrationName => _a2ARegistration?.AppName;
+
+        /// <summary>
+        /// A2A vault registration name
+        /// </summary>
+        public string A2AVaultRegistrationName => _a2AVaultRegistration?.AppName;
+
+        /// <summary>
+        /// A2A registration
+        /// </summary>
+        public A2ARegistration A2ARegistration
+        {
+            get => _a2ARegistration; 
+            set => _a2ARegistration = value;
+        }
+
+        /// <summary>
+        /// A2A vault registration
+        /// </summary>
+        public A2ARegistration A2AVaultRegistration
+        {
+            get => _a2AVaultRegistration; 
+            set => _a2AVaultRegistration = value;
+        }
+
+        /// <summary>
+        /// Asset
+        /// </summary>
+        public Asset Asset
+        {
+            get => _asset; 
+            set => _asset = value;
+        }
+
+        /// <summary>
+        /// Asset partition
+        /// </summary>
+        public AssetPartition AssetPartition
+        {
+            get => _assetPartition; 
+            set => _assetPartition = value;
+        }
 
         /// <summary>
         /// Session key
@@ -82,9 +139,13 @@ namespace OneIdentity.DevOps.Data
         /// </summary>
         public ServiceConfiguration(LoggedInUser loggedInUser)
         {
-            AdminRoles = loggedInUser.AdminRoles;
-            UserName = loggedInUser.UserName;
-            IdentityProviderName = loggedInUser.IdentityProviderName;
+            _a2AUser = new A2AUser()
+            {
+                AdminRoles = loggedInUser.AdminRoles,
+                UserName = loggedInUser.UserName,
+                IdentityProviderName = loggedInUser.IdentityProviderName,
+                Id = loggedInUser.Id
+            };
         }
 
         /// <summary>
@@ -93,6 +154,18 @@ namespace OneIdentity.DevOps.Data
         public bool Compare(string token)
         {
             return token.Equals(_accessToken.ToInsecureString());
+        }
+
+        /// <summary>
+        /// Clear properties
+        /// </summary>
+        public void Clear()
+        {
+            _a2AUser = null;
+            _a2ARegistration = null;
+            _a2AVaultRegistration = null;
+            _asset = null;
+            _assetPartition = null;
         }
 
         /// <summary>

--- a/SafeguardDevOpsService/Data/Spp/DevOpsSecretsBroker.cs
+++ b/SafeguardDevOpsService/Data/Spp/DevOpsSecretsBroker.cs
@@ -23,16 +23,6 @@ namespace OneIdentity.DevOps.Data.Spp
         public string Host { get; set; }
 
         /// <summary>
-        /// The Secrets Broker asset id.
-        /// </summary>
-        public int AssetId { get; set; }
-
-        /// <summary>
-        /// The Secrets Broker asset name.
-        /// </summary>
-        public string AssetName { get; set; }
-
-        /// <summary>
         /// The accounts to plugins mapping.
         /// </summary>
         public string AccountMapping { get; set; }
@@ -55,7 +45,17 @@ namespace OneIdentity.DevOps.Data.Spp
         /// <summary>
         /// The asset partition.
         /// </summary>
+        public Asset Asset { get; set; }
+
+        /// <summary>
+        /// The asset partition.
+        /// </summary>
         public AssetPartition AssetPartition { get; set; }
+
+        /// <summary>
+        /// The A2A user.
+        /// </summary>
+        public A2AUser A2AUser { get; set; }
 
         /// <summary>
         /// Set of asset accounts that are assigned to this devops secrets broker

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -43,9 +43,11 @@ namespace OneIdentity.DevOps.Logic
         void RemoveA2ARetrievableAccounts(ISafeguardConnection sgConnection, IEnumerable<A2ARetrievableAccount> accounts, A2ARegistrationType registrationType);
 
         List<DevOpsSecretsBrokerAccount> GetSecretsBrokerAccounts(ISafeguardConnection sg);
+        void RetrieveDevOpsSecretsBrokerInstance(ISafeguardConnection sgConnection);
         void AddSecretsBrokerInstance(ISafeguardConnection sgConnection);
         void UpdateSecretsBrokerInstance(ISafeguardConnection sg, DevOpsSecretsBroker devOpsSecretsBroker);
-        Asset GetAsset(ISafeguardConnection sg, int id);
+        Asset GetAsset(ISafeguardConnection sg);
+        AssetPartition GetAssetPartition(ISafeguardConnection sg);
 
         ServiceConfiguration GetDevOpsConfiguration(ISafeguardConnection sgConnection);
         ServiceConfiguration ConfigureDevOpsService();

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -29,9 +30,18 @@ namespace OneIdentity.DevOps.Logic
         private readonly IConfigurationRepository _configDb;
 
         private ServiceConfiguration _serviceConfiguration;
-        private DevOpsSecretsBroker _devOpsSecretsBroker { get; set; }
+        private DevOpsSecretsBroker _devOpsSecretsBroker;
 
-        public DevOpsSecretsBroker DevOpsSecretsBroker => _devOpsSecretsBroker;
+        public DevOpsSecretsBroker DevOpsSecretsBroker
+        {
+            get => _devOpsSecretsBroker;
+            private set
+            {
+                _devOpsSecretsBroker = value;
+                _configDb.AssetId = _devOpsSecretsBroker?.Asset?.Id;
+                _configDb.A2aUserId = _devOpsSecretsBroker?.A2AUser?.Id;
+            }
+        }
 
         public SafeguardLogic(IConfigurationRepository configDb)
         {
@@ -274,12 +284,16 @@ namespace OneIdentity.DevOps.Logic
                 var a2aUserStr = JsonHelper.SerializeObject(a2aUser);
                 try
                 {
-                    var result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Post, "Users",
-                        a2aUserStr);
+                    var result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Post, "Users", a2aUserStr);
                     if (result.StatusCode == HttpStatusCode.Created)
                     {
                         a2aUser = JsonHelper.DeserializeObject<A2AUser>(result.Body);
-                        _configDb.A2aUserId = a2aUser.Id;
+                        if (DevOpsSecretsBroker?.A2AUser == null ||
+                            DevOpsSecretsBroker.A2AUser.Id != a2aUser.Id)
+                        {
+                            DevOpsSecretsBroker.A2AUser = a2aUser;
+                            UpdateSecretsBrokerInstance(sg, DevOpsSecretsBroker);
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -296,13 +310,23 @@ namespace OneIdentity.DevOps.Logic
                     {
                         a2aUser.PrimaryAuthenticationIdentity = thumbprint;
                         var a2aUserStr = JsonHelper.SerializeObject(a2aUser);
-                        DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Put, $"Users/{a2aUser.Id}",
-                            a2aUserStr);
+                        var result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Put, $"Users/{a2aUser.Id}", a2aUserStr);
+                        if (result.StatusCode == HttpStatusCode.OK)
+                        {
+                            a2aUser = JsonHelper.DeserializeObject<A2AUser>(result.Body);
+                        }
                     }
                     catch (Exception ex)
                     {
                         throw LogAndException($"Failed to update the A2A user: {ex.Message}", ex);
                     }
+                }
+
+                if (DevOpsSecretsBroker?.A2AUser == null ||
+                    DevOpsSecretsBroker.A2AUser.Id != a2aUser.Id)
+                {
+                    DevOpsSecretsBroker.A2AUser = a2aUser;
+                    UpdateSecretsBrokerInstance(sg, DevOpsSecretsBroker);
                 }
             }
         }
@@ -332,7 +356,12 @@ namespace OneIdentity.DevOps.Logic
                             if (foundUsers.Count > 0)
                             {
                                 var a2aUser = foundUsers.FirstOrDefault();
-                                _configDb.A2aUserId = a2aUser.Id;
+                                if (a2aUser != null && _configDb.A2aUserId != a2aUser.Id)
+                                {
+                                    _configDb.A2aUserId = a2aUser.Id;
+                                    DevOpsSecretsBroker.A2AUser = a2aUser;
+                                }
+
                                 return a2aUser;
                             }
                         }
@@ -455,34 +484,12 @@ namespace OneIdentity.DevOps.Logic
                         throw LogAndException($"Failed to create the A2A registration: {ex.Message}", ex);
                     }
 
-                    AddSecretsBrokerInstance(sg);
-                    if (DevOpsSecretsBroker == null)
-                    {
-                        throw new DevOpsException(
-                            $"Failed to update the Safeguard Secrets Broker instance {_configDb.SvcId}");
-                    }
-
                     DevOpsSecretsBroker.A2ARegistration = new A2ARegistration()
                     {
                         Id = registration.Id
                     };
-                    var devOpsInstanceBody = JsonHelper.SerializeObject(DevOpsSecretsBroker);
 
-                    try
-                    {
-                        var result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Put,
-                            $"DevOps/SecretsBrokers/{DevOpsSecretsBroker.Id}", devOpsInstanceBody);
-                        if (result.StatusCode == HttpStatusCode.OK)
-                        {
-                            _devOpsSecretsBroker = JsonHelper.DeserializeObject<DevOpsSecretsBroker>(result.Body);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        throw LogAndException(
-                            $"Failed to update the A2A registration associated with the Safeguard Secrets Broker instance {_configDb.SvcId}: {ex.Message}",
-                            ex);
-                    }
+                    UpdateSecretsBrokerInstance(sg, DevOpsSecretsBroker);
                 }
             }
             finally
@@ -557,7 +564,9 @@ namespace OneIdentity.DevOps.Logic
                     }
                     catch (Exception ex)
                     {
-                        throw LogAndException($"Failed to get the registration for id '{registrationId}'", ex);
+                        // Just log the exception and set the registration id in the databsae to null.  If there is a
+                        //  registration that matches, it will find it the next time.
+                        _logger.Error(ex, $"Failed to get the registration for id '{registrationId}': {ex.Message}");
                     }
                 }
 
@@ -1089,6 +1098,25 @@ namespace OneIdentity.DevOps.Logic
             return ConnectAnonymous(_configDb.SafeguardAddress, _configDb.ApiVersion ?? WellKnownData.DefaultApiVersion, true);
         }
 
+        public void RetrieveDevOpsSecretsBrokerInstance(ISafeguardConnection sgConnection)
+        {
+            var sg = sgConnection ?? Connect();
+
+            try {
+                var secretsBroker = GetSecretsBrokerInstanceByName(sg);
+                if (secretsBroker != null)
+                {
+                    DevOpsSecretsBroker = secretsBroker;
+                }
+            }
+            finally
+            {
+                if (sgConnection == null)
+                    sg.Dispose();
+            }
+
+        }
+
         public SafeguardDevOpsConnection SetSafeguardData(string token, SafeguardData safeguardData)
         {
             if (token == null)
@@ -1144,6 +1172,7 @@ namespace OneIdentity.DevOps.Logic
             }
 
             _configDb.DropDatabase();
+            _configDb.SvcId = WellKnownData.ServiceIdentitifierRegenerate;
             RestartService();
         }
 
@@ -1162,7 +1191,7 @@ namespace OneIdentity.DevOps.Logic
             }
 
             DeleteSafeguardData();
-            _devOpsSecretsBroker = null;
+            DevOpsSecretsBroker = null;
             DisconnectWithAccessToken();
         }
 
@@ -1571,6 +1600,8 @@ namespace OneIdentity.DevOps.Logic
                         {
                             Id = a2aRegistration.Id
                         };
+                        devOpsSecretsBroker.A2AUser = a2aUser;
+
                         var devOpsInstanceBody = JsonHelper.SerializeObject(devOpsSecretsBroker);
 
                         try
@@ -1579,7 +1610,7 @@ namespace OneIdentity.DevOps.Logic
                                 $"DevOps/SecretsBrokers/{devOpsSecretsBroker.Id}", devOpsInstanceBody);
                             if (result.StatusCode == HttpStatusCode.OK)
                             {
-                                _devOpsSecretsBroker = JsonHelper.DeserializeObject<DevOpsSecretsBroker>(result.Body);
+                                DevOpsSecretsBroker = JsonHelper.DeserializeObject<DevOpsSecretsBroker>(result.Body);
                             }
                         }
                         catch (Exception ex)
@@ -1842,22 +1873,9 @@ namespace OneIdentity.DevOps.Logic
 
         public ServiceConfiguration GetDevOpsConfiguration(ISafeguardConnection sgConnection)
         {
-            _serviceConfiguration.IdentityProviderName = null;
-            _serviceConfiguration.UserName = null;
-            _serviceConfiguration.UserDisplayName = null;
-            _serviceConfiguration.AdminRoles = null;
-            _serviceConfiguration.A2ARegistrationName = null;
-            _serviceConfiguration.A2AVaultRegistrationName = null;
-            _serviceConfiguration.Thumbprint = null;
+            _serviceConfiguration.Clear();
 
-            var a2aUser = GetA2AUser(sgConnection);
-            if (a2aUser != null)
-            {
-                _serviceConfiguration.IdentityProviderName = a2aUser.IdentityProviderName;
-                _serviceConfiguration.UserName = a2aUser.UserName;
-                _serviceConfiguration.UserDisplayName = a2aUser.DisplayName;
-                _serviceConfiguration.AdminRoles = a2aUser.AdminRoles;
-            }
+            _serviceConfiguration.A2AUser = GetA2AUser(sgConnection);
 
             _serviceConfiguration.Appliance = GetSafeguardAvailability(sgConnection,
                 new SafeguardDevOpsConnection()
@@ -1867,19 +1885,10 @@ namespace OneIdentity.DevOps.Logic
                     ApiVersion = _configDb.ApiVersion ?? WellKnownData.DefaultApiVersion
                 });
 
-            var a2aRegistration = GetA2ARegistration(sgConnection, A2ARegistrationType.Account);
-            if (a2aRegistration != null)
-            {
-                _serviceConfiguration.A2ARegistrationName = a2aRegistration.AppName;
-            }
-
-            a2aRegistration = GetA2ARegistration(sgConnection, A2ARegistrationType.Vault);
-            if (a2aRegistration != null)
-            {
-                _serviceConfiguration.A2AVaultRegistrationName = a2aRegistration.AppName;
-            }
-
-            _serviceConfiguration.Thumbprint = _configDb.UserCertificate?.Thumbprint;
+            _serviceConfiguration.A2ARegistration = GetA2ARegistration(sgConnection, A2ARegistrationType.Account);
+            _serviceConfiguration.A2AVaultRegistration = GetA2ARegistration(sgConnection, A2ARegistrationType.Vault);
+            _serviceConfiguration.Asset = GetAsset(sgConnection);
+            _serviceConfiguration.AssetPartition = GetAssetPartition(sgConnection);
 
             return _serviceConfiguration;
         }
@@ -1893,10 +1902,11 @@ namespace OneIdentity.DevOps.Logic
 
                 try
                 {
-                    var secretsBroker = GetSecretsBrokerInstanceByName(sgConnection);
+                    var secretsBroker = GetSecretsBrokerInstanceByName(sg);
                     if (secretsBroker != null)
                     {
-                        _devOpsSecretsBroker = secretsBroker;
+                        DevOpsSecretsBroker = secretsBroker;
+                        return;
                     }
 
                     var addresses = GetLocalIPAddresses();
@@ -1908,8 +1918,8 @@ namespace OneIdentity.DevOps.Logic
                         {
                             Host = ipAddress.ToString(),
                             DevOpsInstanceId = _configDb.SvcId,
-                            AssetName = WellKnownData.DevOpsAssetName + "-" + ipAddress,
-                            AssetPartition = new AssetPartition() {Name = WellKnownData.DevOpsAssetName + "-" + _configDb.SvcId}
+                            Asset = new Asset() {Name = WellKnownData.DevOpsAssetName(_configDb.SvcId)},
+                            AssetPartition = new AssetPartition() {Name = WellKnownData.DevOpsAssetPartitionName(_configDb.SvcId)}
                         };
 
                         var secretsBrokerStr = JsonHelper.SerializeObject(secretsBroker);
@@ -1919,7 +1929,7 @@ namespace OneIdentity.DevOps.Logic
                                 secretsBrokerStr);
                             if (result.StatusCode == HttpStatusCode.Created)
                             {
-                                _devOpsSecretsBroker = JsonHelper.DeserializeObject<DevOpsSecretsBroker>(result.Body);
+                                DevOpsSecretsBroker = JsonHelper.DeserializeObject<DevOpsSecretsBroker>(result.Body);
                                 return;
                             }
                         }
@@ -1951,14 +1961,17 @@ namespace OneIdentity.DevOps.Logic
             if (devOpsSecretsBroker.Host == null)
                 throw LogAndException("Invalid devOps secrets broker instance.  The host cannot be null.");
 
-            if (devOpsSecretsBroker.AssetId == 0)
-                devOpsSecretsBroker.AssetName = WellKnownData.DevOpsAssetName + "-" + devOpsSecretsBroker.Host;
+            if (devOpsSecretsBroker.Asset == null)
+                devOpsSecretsBroker.Asset = new Asset();
+
+            if (devOpsSecretsBroker.Asset.Id == 0)
+                devOpsSecretsBroker.Asset.Name = WellKnownData.DevOpsAssetName(_configDb.SvcId);
 
             if (devOpsSecretsBroker.AssetPartition == null)
                 devOpsSecretsBroker.AssetPartition = new AssetPartition();
 
-            if (devOpsSecretsBroker.AssetId == 0)
-                devOpsSecretsBroker.AssetName = WellKnownData.DevOpsAssetName + "-" + devOpsSecretsBroker.DevOpsInstanceId;
+            if (devOpsSecretsBroker.AssetPartition.Id == 0)
+                devOpsSecretsBroker.AssetPartition.Name = WellKnownData.DevOpsAssetPartitionName(_configDb.SvcId);
 
             var devopsSecretsBrokerStr = JsonHelper.SerializeObject(devOpsSecretsBroker);
             try
@@ -1967,7 +1980,7 @@ namespace OneIdentity.DevOps.Logic
                     $"DevOps/SecretsBrokers/{devOpsSecretsBroker.Id}", devopsSecretsBrokerStr);
                 if (result.StatusCode == HttpStatusCode.OK)
                 {
-                    _devOpsSecretsBroker = JsonHelper.DeserializeObject<DevOpsSecretsBroker>(result.Body);
+                    DevOpsSecretsBroker = JsonHelper.DeserializeObject<DevOpsSecretsBroker>(result.Body);
                 }
             }
             catch (Exception ex)
@@ -1976,15 +1989,84 @@ namespace OneIdentity.DevOps.Logic
             }
         }
 
-        public Asset GetAsset(ISafeguardConnection sg, int id)
+        public Asset GetAsset(ISafeguardConnection sgConnection)
         {
-            FullResponse result;
+            var sg = sgConnection ?? Connect();
 
-            if (id >= 0)
+            try
+            {
+                FullResponse result;
+
+                // If we don't have an asset Id then try to find the asset by name
+                if (_configDb.AssetId == null)
+                {
+                    var ipAddress = LocalIPAddress();
+                    var knownAssetName = WellKnownData.DevOpsAssetName(_configDb.SvcId);
+                    try
+                    {
+                        var p = new Dictionary<string, string>
+                            {{"filter", $"Name eq '{knownAssetName}'"}};
+
+                        result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Get, "Assets", null, p);
+                        if (result.StatusCode == HttpStatusCode.OK)
+                        {
+                            var foundAssets = JsonHelper.DeserializeObject<List<Asset>>(result.Body);
+
+                            if (foundAssets.Count > 0)
+                            {
+                                var asset = foundAssets.FirstOrDefault();
+                                if (asset != null)
+                                {
+                                    _configDb.AssetId = asset.Id;
+                                }
+
+                                return asset;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Error(ex, $"Failed to get the asset by name {knownAssetName}: {ex.Message}");
+                    }
+                }
+                else // Otherwise just get the asset by id
+                {
+                    var assetId = _configDb.AssetId;
+                    try
+                    {
+                        var asset = GetAsset(sg, DevOpsSecretsBroker.Id);
+                        if (asset != null)
+                        {
+                            return asset;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // Just log the error and move on.  This will set the asset id in the database to null.
+                        //  If there is actually an asset that matches, it will find it the next time.
+                        _logger.Error(ex, $"Failed to get the asset for id '{assetId}': {ex.Message}");
+                    }
+                }
+
+                // Apparently the asset id we have is wrong so get rid of it.
+                _configDb.AssetId = null;
+            }
+            finally
+            {
+                if (sgConnection == null)
+                    sg.Dispose();
+            }
+
+            return null;
+        }
+
+        private Asset GetAsset(ISafeguardConnection sg, int? id)
+        {
+            if (id != null)
             {
                 try
                 {
-                    result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Get, $"DevOps/SecretsBrokers/{id}/Asset");
+                    var result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Get, $"DevOps/SecretsBrokers/{id}/Asset");
                     if (result.StatusCode == HttpStatusCode.OK)
                     {
                         return JsonHelper.DeserializeObject<Asset>(result.Body);
@@ -2010,35 +2092,107 @@ namespace OneIdentity.DevOps.Logic
             return null;
         }
 
-        // public Asset GetAssetByName(ISafeguardConnection sg, string assetName)
-        // {
-        //     FullResponse result;
-        //
-        //     if (assetName != null)
-        //     {
-        //         var p = new Dictionary<string, string>
-        //             {{"filter", $"Name eq '{assetName}'"}};
-        //
-        //         try
-        //         {
-        //             result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Get, "Assets", null, p);
-        //             if (result.StatusCode == HttpStatusCode.OK)
-        //             {
-        //                 var foundAssets = JsonHelper.DeserializeObject<List<Asset>>(result.Body);
-        //                 if (foundAssets.Any())
-        //                 {
-        //                     return foundAssets.FirstOrDefault();
-        //                 }
-        //             }
-        //         }
-        //         catch (Exception ex)
-        //         {
-        //             _logger.Error(ex, $"Failed to get the asset by name: {ex.Message}");
-        //         }
-        //     }
-        //
-        //     return null;
-        // }
+        public AssetPartition GetAssetPartition(ISafeguardConnection sgConnection)
+        {
+            var sg = sgConnection ?? Connect();
+
+            try
+            {
+                FullResponse result;
+
+                // If we don't have an asset partition Id then try to find the asset partition by name
+                if (_configDb.AssetPartitionId == null)
+                {
+                    var knownAssetPartitionName = WellKnownData.DevOpsAssetPartitionName(_configDb.SvcId);
+                    try
+                    {
+                        var p = new Dictionary<string, string>
+                            {{"filter", $"Name eq '{knownAssetPartitionName}'"}};
+
+                        result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Get, "AssetPartitions", null, p);
+                        if (result.StatusCode == HttpStatusCode.OK)
+                        {
+                            var foundAssetPartitions = JsonHelper.DeserializeObject<List<AssetPartition>>(result.Body);
+
+                            if (foundAssetPartitions.Count > 0)
+                            {
+                                var assetPartition = foundAssetPartitions.FirstOrDefault();
+                                if (assetPartition != null)
+                                {
+                                    _configDb.AssetPartitionId = assetPartition.Id;
+                                }
+
+                                return assetPartition;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Error(ex, $"Failed to get the asset partition by name {knownAssetPartitionName}: {ex.Message}");
+                    }
+                }
+                else // Otherwise just get the registration by id
+                {
+                    var assetPartitionId = _configDb.AssetPartitionId;
+                    try
+                    {
+                        var assetPartition = GetAssetPartition(sg, assetPartitionId);
+                        if (assetPartition != null)
+                        {
+                            return assetPartition;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // Just log the error and move on. If there is an asset partition that matches, Secrets Broker will find it
+                        //  the next time.
+                        _logger.Error(ex, $"Failed to get the asset partition for id '{assetPartitionId}': {ex.Message}");
+                    }
+                }
+
+                // Apparently the asset partition id we have is wrong so get rid of it.
+                _configDb.AssetPartitionId = null;
+            }
+            finally
+            {
+                if (sgConnection == null)
+                    sg.Dispose();
+            }
+
+            return null;
+        }
+
+        private AssetPartition GetAssetPartition(ISafeguardConnection sg, int? id)
+        {
+            if (id != null)
+            {
+                try
+                {
+                    var result = DevOpsInvokeMethodFull(_configDb.SvcId, sg, Service.Core, Method.Get, $"AssetPartitions/{id}");
+                    if (result.StatusCode == HttpStatusCode.OK)
+                    {
+                        return JsonHelper.DeserializeObject<AssetPartition>(result.Body);
+                    }
+                }
+                catch (SafeguardDotNetException ex)
+                {
+                    if (ex.HttpStatusCode == HttpStatusCode.NotFound)
+                    {
+                        _logger.Error($"Asset partition not found for id '{id}'", ex);
+                    }
+                    else
+                    {
+                        throw LogAndException($"Failed to get the asset partition for id '{id}'", ex);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw LogAndException($"Failed to get the asset partition for id '{id}'", ex);
+                }
+            }
+
+            return null;
+        }
 
         public void Dispose()
         {

--- a/SafeguardDevOpsService/Logic/WellKnownData.cs
+++ b/SafeguardDevOpsService/Logic/WellKnownData.cs
@@ -20,7 +20,6 @@ namespace OneIdentity.DevOps.Logic
         public const string PluginInfoClassName = "PluginDescriptor";
 
         public const string DevOpsServiceName = "SafeguardDevOpsService";
-        public const string DevOpsAssetName = DevOpsServiceName;
 
         private const string DevOpsServiceUserName = "SafeguardDevOpsUser";
         private const string DevOpsA2ARegistrationName = DevOpsServiceName;
@@ -44,6 +43,8 @@ namespace OneIdentity.DevOps.Logic
 
         public const string PluginsDeleteFile = "DeletePlugins.all";
         public const string AddonDeleteFile = "DeleteAddon.all";
+
+        public const string ServiceIdentitifierRegenerate = "NEVER-INSTALLED";
 
 
         public static readonly string ProgramDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), DevOpsServiceName);
@@ -87,6 +88,16 @@ namespace OneIdentity.DevOps.Logic
         public static string DevOpsVaultRegistrationName(string svcId)
         {
             return $"{DevOpsVaultA2ARegistrationName}-{svcId}";
+        }
+
+        public static string DevOpsAssetName(string svcId)
+        {
+            return $"{DevOpsServiceName}-{svcId}";
+        }
+
+        public static string DevOpsAssetPartitionName(string svcId)
+        {
+            return $"{DevOpsServiceName}-{svcId}";
         }
 
         public static string DevOpsServiceClientCertificate(string svcId)

--- a/SafeguardDevOpsService/SafeguardDevOpsService.cs
+++ b/SafeguardDevOpsService/SafeguardDevOpsService.cs
@@ -147,7 +147,7 @@ namespace OneIdentity.DevOps
                 Log.Logger.Information($"Failed to read the service instance identifier: {WellKnownData.SvcIdPath}", ex);
             }
 
-            if (svcId == null || svcId.Equals("NEVER-INSTALLED", StringComparison.InvariantCultureIgnoreCase))
+            if (svcId == null || svcId.Equals(WellKnownData.ServiceIdentitifierRegenerate, StringComparison.OrdinalIgnoreCase))
             {
                 try
                 {


### PR DESCRIPTION
 so that it doesn't try to find an existing A2A registration until after it is configured.  Use the cut down versions of the AssetPartition and User classes.