### PR TITLE
TFS 281224: [UI] Allow the admin to provide an alternate account name then mapping accounts to plugins

### DIFF
--- a/SafeguardDevOpsService/ClientApp/src/app/edit-plugin/edit-plugin.component.html
+++ b/SafeguardDevOpsService/ClientApp/src/app/edit-plugin/edit-plugin.component.html
@@ -68,6 +68,7 @@
       <div>
         <table mat-table [dataSource]="plugin.Accounts">
           <ng-container matColumnDef="asset">
+            <th mat-header-cell *matHeaderCellDef>Asset</th>
             <td mat-cell *matCellDef="let element">
               <span>{{element.SystemName}}</span>
               <div class="detail-row">{{element.SystemNetworkAddress}}</div>
@@ -75,20 +76,32 @@
           </ng-container>
 
           <ng-container matColumnDef="account">
+            <th mat-header-cell *matHeaderCellDef>Account</th>
             <td mat-cell *matCellDef="let element">
               <span>{{element.Name}}</span>
               <div class="detail-row">{{element.DomainName}}</div>
             </td>
           </ng-container>
 
+          <ng-container matColumnDef="altaccount">
+            <th mat-header-cell *matHeaderCellDef>Alternate</th>
+            <td mat-cell *matCellDef="let element">
+              <div class="center">
+                <input matInput type="text" [(ngModel)]="element.AltAccountName">
+              </div>
+            </td>
+          </ng-container>
+
           <ng-container matColumnDef="delete">
+            <th mat-header-cell *matHeaderCellDef>Remove</th>
             <td mat-cell *matCellDef="let row">
               <button mat-icon-button (click)="removeAccount($event, row)" color="primary" [disabled]="isSaving">
-                <mat-icon>delete</mat-icon>
+                <mat-icon>remove</mat-icon>
               </button>
             </td>
           </ng-container>
 
+          <tr mat-header-row *matHeaderRowDef="displayedColumns;"></tr>
           <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
         </table>
       </div>

--- a/SafeguardDevOpsService/ClientApp/src/app/edit-plugin/edit-plugin.component.ts
+++ b/SafeguardDevOpsService/ClientApp/src/app/edit-plugin/edit-plugin.component.ts
@@ -33,7 +33,7 @@ export class EditPluginComponent implements OnInit {
   isTesting = false;
   isRestarting = false;
   isDeleting = false;
-  displayedColumns: string[] = ['asset', 'account', 'delete'];
+  displayedColumns: string[] = ['asset', 'account', 'altaccount', 'delete'];
   isPluginDisabled: boolean;
 
   ngOnInit(): void {


### PR DESCRIPTION
Edit Plugin:
Add Managed Account grid headers
Add Alternate column with simple bound input for edit in place
Change trash can (delete) to dash (remove) since the SG accounts are not getting deleted.