### PR TITLE
Require asset admin permissions on certain endpoints.

### DIFF
--- a/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Principal;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,7 @@ using OneIdentity.DevOps.Data;
 using OneIdentity.DevOps.Data.Spp;
 using OneIdentity.DevOps.Exceptions;
 using OneIdentity.DevOps.Logic;
+using OneIdentity.SafeguardDotNet;
 using A2ARetrievableAccount = OneIdentity.DevOps.Data.Spp.A2ARetrievableAccount;
 #pragma warning disable 1573
 
@@ -76,40 +78,6 @@ namespace OneIdentity.DevOps.Controllers.V1
         }
 
         /// <summary>
-        /// Delete the Safeguard appliance connection information being used by Safeguard Secrets Broker for DevOps.
-        /// </summary>
-        /// <remarks>
-        /// Safeguard Secrets Broker for DevOps must be associated with a Safeguard for Privileged Passwords appliance before it can be used.
-        /// This appliance will be trusted for authentication.  It is also the appliance that will notify Safeguard Secrets Broker for DevOps
-        /// of secret changes so that they can be pushed to the configured plugins.
-        ///
-        /// This endpoint will remove the currently configured association.  It does not clean up any of Safeguard Secrets Broker for DevOps
-        /// related items added to the Safeguard for Privileged Passwords configuration.  Those must be removed manually.
-        ///
-        /// It will also remove Safeguard Secrets Broker for DevOps configuration database and restart the DevOps service.
-        ///
-        /// To help prevent unintended Safeguard appliance connection removal, the confirm query param is required and must be set to "yes".
-        ///
-        /// (see DELETE /service/devops/{version}/Safeguard/Configuration)
-        /// </remarks>
-        /// <param name="confirm">This query parameter must be set to "yes" if the caller intends to remove the Safeguard appliance connection.</param>
-        /// <response code="204">Success.</response>
-        /// <response code="400">Bad Request</response>
-        [SafeguardSessionKeyAuthorization]
-        [SafeguardSessionHandler]
-        [UnhandledExceptionError]
-        [HttpDelete]
-        public ActionResult DeleteSafeguard([FromServices] ISafeguardLogic safeguard, [FromQuery] string confirm)
-        {
-            if (confirm == null || !confirm.Equals("yes", StringComparison.InvariantCultureIgnoreCase))
-                return BadRequest();
-
-            safeguard.DeleteSafeguardData();
-
-            return NoContent();
-        }
-
-        /// <summary>
         /// Get the Safeguard client configuration information being used by Safeguard Secrets Broker for DevOps.
         /// </summary>
         /// <remarks>
@@ -152,7 +120,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         /// replaces the need to install the certificate separately.</param>
         /// <response code="200">Success.</response>
         /// <response code="400">Bad request.</response>
-        [SafeguardSessionKeyAuthorization]
+        [SafeguardSessionKeyAuthorization(WellKnownData.SafeguardAssetAdmin)]
         [SafeguardSessionHandler]
         [UnhandledExceptionError]
         [HttpPost("Configuration")]
@@ -935,7 +903,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         /// </remarks>
         /// <response code="200">Success.</response>
         /// <response code="400">Bad request.</response>
-        [SafeguardSessionKeyAuthorization]
+        [SafeguardSessionKeyAuthorization(WellKnownData.SafeguardAssetAdmin)]
         [SafeguardSessionHandler]
         [UnhandledExceptionError]
         [HttpPost("Addons/{addonName}/Configuration")]

--- a/SafeguardDevOpsService/Data/SafeguardDevOpsConnection.cs
+++ b/SafeguardDevOpsService/Data/SafeguardDevOpsConnection.cs
@@ -30,6 +30,14 @@
         /// </summary>
         public string DevOpsInstanceId { get; set; }
         /// <summary>
+        /// Logged in user name
+        /// </summary>
+        public string UserName { get; set; }
+        /// <summary>
+        /// Logged in user roles
+        /// </summary>
+        public string[] AdminRoles { get; set; }
+        /// <summary>
         /// Safeguard DevOps version
         /// </summary>
         public string Version { get; set; }

--- a/SafeguardDevOpsService/Data/ServiceConfiguration.cs
+++ b/SafeguardDevOpsService/Data/ServiceConfiguration.cs
@@ -13,16 +13,12 @@ namespace OneIdentity.DevOps.Data
     {
         private SecureString _accessToken;
         private string _sessionKey = Guid.NewGuid().ToString();
-        private A2ARegistration _a2ARegistration;
-        private A2ARegistration _a2AVaultRegistration;
-        private A2AUser _a2AUser;
-        private Asset _asset;
-        private AssetPartition _assetPartition;
 
         /// <summary>
         /// Service is authenticated
         /// </summary>
         public bool IsAuthenticated => _accessToken != null;
+
         /// <summary>
         /// Safeguard appliance information
         /// </summary>
@@ -39,55 +35,15 @@ namespace OneIdentity.DevOps.Data
         }
 
         /// <summary>
-        /// A2A Certificate User
+        /// Logged in user
         /// </summary>
-        public A2AUser A2AUser
-        {
-            get => _a2AUser; 
-            set => _a2AUser = value;
-        }
-
-        /// <summary>
-        /// A2A registration
-        /// </summary>
-        public A2ARegistration A2ARegistration
-        {
-            get => _a2ARegistration; 
-            set => _a2ARegistration = value;
-        }
-
-        /// <summary>
-        /// A2A vault registration
-        /// </summary>
-        public A2ARegistration A2AVaultRegistration
-        {
-            get => _a2AVaultRegistration; 
-            set => _a2AVaultRegistration = value;
-        }
-
-        /// <summary>
-        /// Asset
-        /// </summary>
-        public Asset Asset
-        {
-            get => _asset; 
-            set => _asset = value;
-        }
-
-        /// <summary>
-        /// Asset partition
-        /// </summary>
-        public AssetPartition AssetPartition
-        {
-            get => _assetPartition; 
-            set => _assetPartition = value;
-        }
+        public LoggedInUser User { get; set; }
 
         /// <summary>
         /// Session key
         /// </summary>
         [JsonIgnore]
-        public string SessionKey
+        public string SessionKey 
         {
             get => _sessionKey;
         }
@@ -104,13 +60,7 @@ namespace OneIdentity.DevOps.Data
         /// </summary>
         public ServiceConfiguration(LoggedInUser loggedInUser)
         {
-            _a2AUser = new A2AUser()
-            {
-                AdminRoles = loggedInUser.AdminRoles,
-                UserName = loggedInUser.UserName,
-                IdentityProviderName = loggedInUser.IdentityProviderName,
-                Id = loggedInUser.Id
-            };
+            User = loggedInUser;
         }
 
         /// <summary>
@@ -126,11 +76,7 @@ namespace OneIdentity.DevOps.Data
         /// </summary>
         public void Clear()
         {
-            _a2AUser = null;
-            _a2ARegistration = null;
-            _a2AVaultRegistration = null;
-            _asset = null;
-            _assetPartition = null;
+            User = null;
         }
 
         /// <summary>

--- a/SafeguardDevOpsService/Logic/AuthorizedCache.cs
+++ b/SafeguardDevOpsService/Logic/AuthorizedCache.cs
@@ -52,9 +52,9 @@ namespace OneIdentity.DevOps.Logic
         {
             return Cache.Values.FirstOrDefault(x =>
                 x.Appliance.ApplianceAddress.Equals(managementConnection.Appliance.ApplianceAddress) 
-                && x.A2AUser != null  
-                && x.A2AUser.IdentityProviderName.Equals(managementConnection.A2AUser?.IdentityProviderName) 
-                && x.A2AUser.UserName.Equals(managementConnection.A2AUser?.UserName));
+                && x.User != null  
+                && x.User.IdentityProviderName.Equals(managementConnection.User?.IdentityProviderName) 
+                && x.User.UserName.Equals(managementConnection.User?.UserName));
         }
 
         public void Remove(string sessionKey)
@@ -67,5 +67,14 @@ namespace OneIdentity.DevOps.Logic
                 }
             }
         }
+
+        public void Clear()
+        {
+            lock (InstanceLock)
+            {
+                Cache.Clear();
+            }
+        }
+
     }
 }

--- a/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/ISafeguardLogic.cs
@@ -17,7 +17,6 @@ namespace OneIdentity.DevOps.Logic
         SafeguardDevOpsConnection GetSafeguardConnection();
         SafeguardDevOpsLogon GetSafeguardLogon();
         SafeguardDevOpsConnection SetSafeguardData(string token, SafeguardData safeguardData);
-        void DeleteSafeguardData();
 
         bool IsLoggedIn();
         bool ValidateLicense();

--- a/SafeguardDevOpsService/Logic/WellKnownData.cs
+++ b/SafeguardDevOpsService/Logic/WellKnownData.cs
@@ -53,6 +53,9 @@ namespace OneIdentity.DevOps.Logic
         public const string SwaggerUrl = "https://{0}/service/core/swagger/v{1}/swagger.json";
         public const string DevOpsSecretsBrokerEndPoints = "/v3/DevOps/SecretsBrokers";
 
+        public const string SafeguardAssetAdmin = "AssetAdmin";
+        public const string SafeguardPolicyAdminAdmin = "PolicyAdmin";
+
 
         public static readonly string ProgramDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), DevOpsServiceName);
         public static readonly string ServiceDirPath = Path.GetDirectoryName(


### PR DESCRIPTION
Add authorization for asset admin only to the safeguard/configuration and addon/configuration endpoints.  Add code to remove all of the SPP elements that are related to secrets broker of indicated.  Add the user information to the DevOpsSecretsBroker instance object