### PR TITLE
TFS 283626: [BUG] [Secrets Broker] Uploading or importing trusted certificates that are already added says it's adding new ones when it's not

### DIFF
--- a/SafeguardDevOpsService/Data/CertificateInfo.cs
+++ b/SafeguardDevOpsService/Data/CertificateInfo.cs
@@ -66,6 +66,12 @@ namespace OneIdentity.DevOps.Data
         /// </summary>
         public string Passphrase { get; set; }
 
+        /// <summary>
+        /// The certificate is new or existing (Read-only)
+        /// </summary>
+        [ReadOnly(true)]
+        public bool IsNew { get; set; }
+
         protected bool Equals(CertificateInfo other)
         {
             return string.Equals(Subject, other.Subject) && string.Equals(IssuedBy, other.IssuedBy) && NotBefore.Equals(other.NotBefore) && NotAfter.Equals(other.NotAfter) && string.Equals(Thumbprint, other.Thumbprint);

--- a/SafeguardDevOpsService/Data/TrustedCertificate.cs
+++ b/SafeguardDevOpsService/Data/TrustedCertificate.cs
@@ -24,7 +24,7 @@ namespace OneIdentity.DevOps.Data
         /// <summary>
         /// Get the certificate information
         /// </summary>
-        public CertificateInfo GetCertificateInfo()
+        public CertificateInfo GetCertificateInfo(bool isNew = true)
         {
             var cert = GetCertificate();
             return new CertificateInfo()
@@ -34,7 +34,8 @@ namespace OneIdentity.DevOps.Data
                 NotBefore = cert.NotBefore,
                 Subject = cert.Subject,
                 Thumbprint = cert.Thumbprint,
-                Base64CertificateData = cert.ToPemFormat()
+                Base64CertificateData = cert.ToPemFormat(),
+                IsNew = isNew
             };
         }
 

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -1862,7 +1862,7 @@ namespace OneIdentity.DevOps.Logic
             return certificate?.GetCertificateInfo();
         }
 
-        private CertificateInfo AddTrustedCertificate(string base64CertificateData)
+        private CertificateInfo AddTrustedCertificate(string base64CertificateData, string passPhrase = null)
         {
             if (base64CertificateData == null)
                 throw LogAndException("Certificate cannot be null");
@@ -1870,7 +1870,7 @@ namespace OneIdentity.DevOps.Logic
             try
             {
                 var certificateBytes = CertificateHelper.ConvertPemToData(base64CertificateData);
-                var cert = new X509Certificate2(certificateBytes);
+                var cert = passPhrase != null ? new X509Certificate2(certificateBytes, passPhrase) : new X509Certificate2(certificateBytes);
                 _logger.Debug(
                     $"Parsed new trusted certificate: subject={cert.SubjectName}, thumbprint={cert.Thumbprint}.");
 
@@ -1879,7 +1879,7 @@ namespace OneIdentity.DevOps.Logic
                 if (existingCert != null)
                 {
                     _logger.Debug("New trusted certificate already exists.");
-                    return existingCert.GetCertificateInfo();
+                    return existingCert.GetCertificateInfo(false);
                 }
 
                 if (!CertificateHelper.ValidateCertificate(cert, CertificateType.Trusted))
@@ -1902,7 +1902,7 @@ namespace OneIdentity.DevOps.Logic
 
         public CertificateInfo AddTrustedCertificate(CertificateInfo certificate)
         {
-            return AddTrustedCertificate(certificate.Base64CertificateData);
+            return AddTrustedCertificate(certificate.Base64CertificateData, certificate.Passphrase);
         }
 
         public void DeleteTrustedCertificate(string thumbPrint)


### PR DESCRIPTION
Add read only flag to CertificateInfo for IsNew defaulting true the UI can parse for appropriate messages when importing or uploading trusted certificates.

AddTrustedCertificate was not handling a passphrase when uploading.