### PR TITLE
Bug 286279: [BUG] [SecretsBroker][UI] The wrong configuration button is showing up for the vault plugin

### DIFF
--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -2469,12 +2469,6 @@ namespace OneIdentity.DevOps.Logic
                 var plugin = _configDb.GetPluginByName(addon.Manifest.PluginName);
                 if (plugin != null)
                 {
-                    if (plugin.IsSystemOwned != addon.Manifest.IsPluginSystemOwned)
-                    {
-                        plugin.IsSystemOwned = addon.Manifest.IsPluginSystemOwned;
-                        _configDb.SavePluginConfiguration(plugin);
-                    }
-
                     if (plugin.IsDisabled != notLicensed)
                     {
                         plugin.IsDisabled = notLicensed;


### PR DESCRIPTION
Fix the plugin so that it is designated as system owned at deploy time if it belongs to an addon.  Also fix the certificate connection to Safeguard in the background thread if TLS is enabled.