### PR TITLE
Update the TLS certificates in the addons whenever the TLS certificate changes in Secrets Broker.

### DIFF
--- a/DevOpsAddonCommon/IAddonService.cs
+++ b/DevOpsAddonCommon/IAddonService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualBasic.CompilerServices;
 using Serilog;
 
 namespace OneIdentity.DevOps.Common
@@ -11,10 +12,11 @@ namespace OneIdentity.DevOps.Common
         string Name { get; set; }
         string DisplayName { get; set; }
         string Description { get; set; }
+        ILogger Logger { get; set; }
+        Tuple<string,string> TlsCertificates { get; set; }
         Tuple<bool, List<string>> GetHealthStatus();
         Addon AddOn { get; set; }
         Task RunAddonServiceAsync(CancellationToken cancellationToken);
-        void SetLogger(ILogger logger);
         void Unload();
     }
 }

--- a/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
+++ b/SafeguardDevOpsService/Controllers/V1/SafeguardController.cs
@@ -894,7 +894,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         }
 
         /// <summary>
-        /// Configure a specific add-on.
+        /// Configure an add-on.
         /// </summary>
         /// <remarks>
         /// Safeguard Secrets Broker for DevOps can be modified to provide additional functionality such as credential vault
@@ -913,6 +913,30 @@ namespace OneIdentity.DevOps.Controllers.V1
                 return BadRequest("Invalid add-on name.");
 
             addonLogic.ConfigureDevOpsAddOn(addonName);
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Restart an add-on.
+        /// </summary>
+        /// <remarks>
+        /// Safeguard Secrets Broker for DevOps can be modified to provide additional functionality such as credential vault
+        /// capability that is compatible with the HashiCorp API.
+        ///
+        /// </remarks>
+        /// <response code="200">Success.</response>
+        /// <response code="400">Bad request.</response>
+        [SafeguardSessionKeyAuthorization]
+        [SafeguardSessionHandler]
+        [UnhandledExceptionError]
+        [HttpPost("Addons/{addonName}/Restart")]
+        public ActionResult RestartAddOn([FromServices] IAddonLogic addonLogic, [FromRoute] string addonName)
+        {
+            if (string.IsNullOrEmpty(addonName))
+                return BadRequest("Invalid add-on name.");
+
+            addonLogic.RestartDevOpsAddOn(addonName);
 
             return Ok();
         }

--- a/SafeguardDevOpsService/Logic/AddonLogic.cs
+++ b/SafeguardDevOpsService/Logic/AddonLogic.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using OneIdentity.DevOps.Common;
@@ -300,6 +301,19 @@ namespace OneIdentity.DevOps.Logic
             {
                 sg.Dispose();
             }
+        }
+
+        public void RestartDevOpsAddOn(string addonName)
+        {
+            var addon = _configDb.GetAddonByName(addonName);
+            if (addon == null)
+            {
+                throw LogAndException($"Add-on {addonName} not found.");
+            }
+
+            _addonManager.ShutdownAddon(addon);
+            Thread.Sleep(TimeSpan.FromSeconds(1));
+            _addonManager.StartAddon(addon);
         }
 
         private void InstallAddon(ZipArchive zipArchive, bool isProduction, bool force)

--- a/SafeguardDevOpsService/Logic/IAddonLogic.cs
+++ b/SafeguardDevOpsService/Logic/IAddonLogic.cs
@@ -16,5 +16,6 @@ namespace OneIdentity.DevOps.Logic
         Addon GetAddon(string addonName);
         AddonStatus GetAddonStatus(string addonName);
         void ConfigureDevOpsAddOn(string addonName);
+        void RestartDevOpsAddOn(string addonName);
     }
 }

--- a/SafeguardDevOpsService/Logic/IAddonManager.cs
+++ b/SafeguardDevOpsService/Logic/IAddonManager.cs
@@ -11,5 +11,6 @@ namespace OneIdentity.DevOps.Logic
         void Run();
         AddonStatus GetAddonStatus(Addon addon, bool isLicensed);
         void ShutdownAddon(Addon addon);
+        void StartAddon(Addon addon);
     }
 }

--- a/SafeguardDevOpsService/Startup.cs
+++ b/SafeguardDevOpsService/Startup.cs
@@ -116,7 +116,7 @@ namespace OneIdentity.DevOps
         {
             builder.RegisterLogger();
             builder.Register(c => new LiteDbConfigurationRepository()).As<IConfigurationRepository>().SingleInstance();
-            builder.Register(c => new SafeguardLogic(c.Resolve<IConfigurationRepository>(), c.Resolve<Func<IPluginsLogic>>(), c.Resolve<Func<IMonitoringLogic>>(), c.Resolve<Func<IAddonLogic>>())).As<ISafeguardLogic>().SingleInstance();
+            builder.Register(c => new SafeguardLogic(c.Resolve<IConfigurationRepository>(), c.Resolve<Func<IPluginsLogic>>(), c.Resolve<Func<IMonitoringLogic>>(), c.Resolve<Func<IAddonLogic>>(), c.Resolve<Func<IAddonManager>>())).As<ISafeguardLogic>().SingleInstance();
             builder.Register(c => new PluginManager(c.Resolve<IConfigurationRepository>(), c.Resolve<ISafeguardLogic>())).As<IPluginManager>().SingleInstance();
             builder.Register(c => new AddonManager(c.Resolve<IConfigurationRepository>())).As<IAddonManager>().SingleInstance();
             builder.Register(c => new PluginsLogic(c.Resolve<IConfigurationRepository>(), c.Resolve<IPluginManager>(), c.Resolve<ISafeguardLogic>())).As<IPluginsLogic>().SingleInstance();


### PR DESCRIPTION
  Add a restart addons so that the user can attempt to recover a failed addon without having to restart the Secrets Broker service.