### PR TITLE
Make sure that there are no duplicate alternate account names. 

### DIFF
--- a/ExternalPlugins/HashiCorpVault/HashiCorpVault.csproj
+++ b/ExternalPlugins/HashiCorpVault/HashiCorpVault.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="VaultSharp" Version="0.11.1002" />
+    <PackageReference Include="VaultSharp" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,12 +28,10 @@
   </ItemGroup>
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\$(ProjectName).zip'&quot;"
-          EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
+    <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\$(ProjectName).zip'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
-  <Target Name="PostBuildLinux" AfterTargets="PostBuildEvent" Condition="'$(OS)' != 'Windows_NT' And '$(SelfContained)' == 'true'" >
-    <Exec Command="$(SolutionDir)zipplugin.sh $(ProjectDir) $(OutDir) $(SolutionDir)ExternalPlugins\bin\$(Configuration)\$(ProjectName).zip"
-          EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
+  <Target Name="PostBuildLinux" AfterTargets="PostBuildEvent" Condition="'$(OS)' != 'Windows_NT' And '$(SelfContained)' == 'true'">
+    <Exec Command="$(SolutionDir)zipplugin.sh $(ProjectDir) $(OutDir) $(SolutionDir)ExternalPlugins\bin\$(Configuration)\$(ProjectName).zip" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 
 </Project>

--- a/SafeguardDevOpsService/ClientApp/src/app/auth.service.ts
+++ b/SafeguardDevOpsService/ClientApp/src/app/auth.service.ts
@@ -15,6 +15,7 @@ export class AuthService {
   login(applianceAddress: string): void {
     const redirect = encodeURIComponent(location.protocol + '//' + location.host + '/main');
     this.window.location.href = 'https://' + applianceAddress + '/RSTS/Login?response_type=token&redirect_uri=' + redirect;
+    this.window.sessionStorage.removeItem('UserToken');
   }
 
   getUserToken(applianceAddress: string): Observable<any> {

--- a/SafeguardDevOpsService/Controllers/V1/PluginsController.cs
+++ b/SafeguardDevOpsService/Controllers/V1/PluginsController.cs
@@ -131,7 +131,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpGet("{name}")]
-        public ActionResult<Plugin> GetPlugin([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name)
+        public ActionResult<Plugin> GetPluginConfiguration([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name)
         {
             var plugin = pluginsLogic.GetPluginByName(name);
             if (plugin == null)
@@ -156,7 +156,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpPut("{name}")]
-        public ActionResult<Plugin> UpdatePlugin([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name, [FromBody] PluginConfiguration pluginConfiguration)
+        public ActionResult<Plugin> UpdatePluginConfiguration([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name, [FromBody] PluginConfiguration pluginConfiguration)
         {
             var plugin = pluginsLogic.SavePluginConfigurationByName(pluginConfiguration, name);
             if (plugin == null)
@@ -184,7 +184,7 @@ namespace OneIdentity.DevOps.Controllers.V1
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpDelete("{name}")]
-        public ActionResult DeletePlugin([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name, [FromQuery] bool restart = false)
+        public ActionResult DeletePluginConfiguration([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name, [FromQuery] bool restart = false)
         {
             pluginsLogic.DeleteAccountMappings(name);
             pluginsLogic.RemovePluginVaultAccount(name);

--- a/SafeguardDevOpsService/Logic/AddonLogic.cs
+++ b/SafeguardDevOpsService/Logic/AddonLogic.cs
@@ -504,7 +504,11 @@ namespace OneIdentity.DevOps.Logic
                         if (addon.Manifest?.Name != null)
                             _configDb.DeleteAddonByName(addon.Manifest.Name);
                         if (addon.Manifest?.PluginName != null)
-                            _configDb.DeletePluginByName(addon.Manifest.PluginName);
+                        {
+                            _pluginsLogic.DeleteAccountMappings(addon.Manifest.PluginName);
+                            _pluginsLogic.RemovePluginVaultAccount(addon.Manifest.PluginName);
+                            _pluginsLogic.DeletePluginByName(addon.Manifest.PluginName);
+                        }
                     }
                 }
             }

--- a/SafeguardDevOpsService/Logic/PluginsLogic.cs
+++ b/SafeguardDevOpsService/Logic/PluginsLogic.cs
@@ -297,6 +297,27 @@ namespace OneIdentity.DevOps.Logic
                 throw new DevOpsException(msg);
             }
 
+            var allAccounts = _configDb.GetAccountMappings().ToArray();
+            foreach (var account in retrievableAccounts)
+            {
+                if (!string.IsNullOrEmpty(account.AltAccountName))
+                {
+                    // Make sure that no other existing account has the same altAccountName
+                    // Make sure that none of the accounts that are being added, have the same altAccountName
+                    if (allAccounts.Any(x => x.AltAccountName != null 
+                                             && x.AltAccountName.Equals(account.AltAccountName, StringComparison.OrdinalIgnoreCase)
+                                             && !x.VaultName.Equals(name, StringComparison.OrdinalIgnoreCase)) 
+                        || retrievableAccounts.Any(x => x.AccountId != account.AccountId 
+                                                        && x.AltAccountName != null 
+                                                        && x.AltAccountName.Equals(account.AltAccountName, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        var msg = $"Invalid alternate account name. The account name {account.AltAccountName} is already in use.";
+                        _logger.Error(msg);
+                        throw new DevOpsException(msg);
+                    }
+                }
+            }
+
             var sg = sgConnection ?? _safeguardLogic.Connect();
 
             try

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -1966,12 +1966,16 @@ namespace OneIdentity.DevOps.Logic
             var safeguardConnection = ConnectAnonymous(safeguardData.ApplianceAddress,
                 safeguardData.ApiVersion ?? WellKnownData.DefaultApiVersion, safeguardData.IgnoreSsl ?? false);
 
+            // If the user is trying to change the state of the ignoreSsl flag back to true, then use the new value.
+            //  If the current value of the flag in the database or the new value is null, then assume true or the current value.
+            safeguardConnection.IgnoreSsl = (safeguardConnection.IgnoreSsl ?? true) || (safeguardData.IgnoreSsl ?? (safeguardConnection.IgnoreSsl ?? true));
+
             _applianceAvailabilityCache = null;
             if (safeguardConnection != null && FetchAndStoreSignatureCertificate(token, safeguardConnection))
             {
                 _configDb.SafeguardAddress = safeguardData.ApplianceAddress;
                 _configDb.ApiVersion = safeguardData.ApiVersion ?? WellKnownData.DefaultApiVersion;
-                _configDb.IgnoreSsl = safeguardData.IgnoreSsl ?? false;
+                _configDb.IgnoreSsl = safeguardData.IgnoreSsl ?? true;
 
                 safeguardConnection.ApplianceAddress = _configDb.SafeguardAddress;
                 safeguardConnection.ApiVersion = _configDb.ApiVersion;


### PR DESCRIPTION
Remove all of the mapped accounts for the addon related plugin when the addon is removed. Allow the user to set the ignoreSSL flag back to true using the API if they get into an authentication trust failure.