### PR TITLE
TFS 288339: [BUG] [SecretsBroker][UI] Add a refresh button to both the Select Vault Account and Select Account panels

### DIFF
--- a/SafeguardDevOpsService/ClientApp/src/app/select-accounts/select-accounts.component.ts
+++ b/SafeguardDevOpsService/ClientApp/src/app/select-accounts/select-accounts.component.ts
@@ -71,6 +71,7 @@ export class SelectAccountsComponent implements OnInit, AfterViewInit {
   }
 
   loadAccounts() {
+    this.editPluginService.clearAvailableAccounts();
     this.assetSearchVal = '';
     this.accountSearchVal = '';
     this.isLoading = true;


### PR DESCRIPTION
Accounts were cached in web, so now a refresh clears the cache.