### PR TITLE
Replace the deprecated Azure keyvaultclient library in the Azure Key Vault plugin. 

### DIFF
--- a/ExternalPlugins/AwsSecretsManagerVault/Manifest.json
+++ b/ExternalPlugins/AwsSecretsManagerVault/Manifest.json
@@ -3,5 +3,5 @@
 	"Name": "AwsSecretsManagerVault",
 	"DisplayName": "AWS Secrets Vault",
 	"Assembly": "AwsSecretsManagerVault.dll",
-	"Version": "1.0.0.9999"
+	"Version": "1.1.0.9999"
 }

--- a/ExternalPlugins/AzureKeyVault/AzureKeyVault.csproj
+++ b/ExternalPlugins/AzureKeyVault/AzureKeyVault.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.8.2" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ExternalPlugins/AzureKeyVault/Manifest.json
+++ b/ExternalPlugins/AzureKeyVault/Manifest.json
@@ -3,5 +3,5 @@
 	"Name": "AzureKeyVault",
 	"DisplayName": "Azure Key Vault",
 	"Assembly": "AzureKeyVault.dll",
-	"Version": "1.0.0.9999"
+	"Version": "2.0.0.9999"
 }

--- a/ExternalPlugins/AzureKeyVault/PluginDescriptor.cs
+++ b/ExternalPlugins/AzureKeyVault/PluginDescriptor.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Microsoft.Azure.KeyVault;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
 using OneIdentity.DevOps.Common;
 using Serilog;
 
@@ -11,13 +11,14 @@ namespace OneIdentity.DevOps.AzureKeyVault
 {
     public class PluginDescriptor : ILoadablePlugin
     {
-        private static IKeyVaultClient _keyVaultClient;
+        private static SecretClient _secretsClient;
         private static Dictionary<string,string> _configuration;
         private static ILogger _logger;
         private static Regex _rgx;
 
         private const string ApplicationIdName = "applicationId";
         private const string VaultUriName = "vaultUri";
+        private const string TenantIdName = "tenantId";
 
         public string Name => "AzureKeyVault";
         public string DisplayName => "Azure Key Vault";
@@ -28,14 +29,15 @@ namespace OneIdentity.DevOps.AzureKeyVault
             return _configuration ??= new Dictionary<string, string>
             {
                 { ApplicationIdName, "" },
-                { VaultUriName, "" }
+                { VaultUriName, "" },
+                { TenantIdName, "" }
             };
         }
 
         public void SetPluginConfiguration(Dictionary<string,string> configuration)
         {
             if (configuration != null && configuration.ContainsKey(ApplicationIdName) &&
-                configuration.ContainsKey(VaultUriName))
+                configuration.ContainsKey(VaultUriName) && configuration.ContainsKey(TenantIdName))
             {
                 _configuration = configuration;
                 _logger.Information($"Plugin {Name} has been successfully configured.");
@@ -51,12 +53,8 @@ namespace OneIdentity.DevOps.AzureKeyVault
         {
             if (_configuration != null)
             {
-                _keyVaultClient = new KeyVaultClient(async (authority, resource, scope) =>
-                {
-                    var adCredential = new ClientCredential(_configuration[ApplicationIdName], credential);
-                    var authenticationContext = new AuthenticationContext(authority, null);
-                    return (await authenticationContext.AcquireTokenAsync(resource, adCredential)).AccessToken;
-                });
+                _secretsClient = new SecretClient(new Uri(_configuration[VaultUriName]),
+                    new ClientSecretCredential(_configuration[TenantIdName], _configuration[ApplicationIdName], credential));
                 _logger.Information($"Plugin {Name} has been successfully authenticated to the Azure vault.");
             }
             else
@@ -67,14 +65,13 @@ namespace OneIdentity.DevOps.AzureKeyVault
 
         public bool TestVaultConnection()
         {
-            if (_keyVaultClient == null)
+            if (_secretsClient == null)
                 return false;
 
             try
             {
-                var task = Task.Run(async () => await _keyVaultClient.GetSecretsAsync(_configuration[VaultUriName]));
-                var result = task.Result;
-                _logger.Information($"Test vault connection for {DisplayName}: Result = {result}");
+                var result = _secretsClient.GetDeletedSecrets();
+                _logger.Information($"Test vault connection for {DisplayName}: Result = {result != null}");
                 return true;
             }
             catch (Exception ex)
@@ -86,7 +83,7 @@ namespace OneIdentity.DevOps.AzureKeyVault
 
         public bool SetPassword(string asset, string account, string password, string altAccountName = null)
         {
-            if (_keyVaultClient == null || _configuration == null || !_configuration.ContainsKey(VaultUriName))
+            if (_secretsClient == null || _configuration == null || !_configuration.ContainsKey(VaultUriName))
             {
                 _logger.Error("No vault connection. Make sure that the plugin has been configured.");
                 return false;
@@ -95,7 +92,7 @@ namespace OneIdentity.DevOps.AzureKeyVault
             try
             {
                 var name = _rgx.Replace(altAccountName ?? $"{asset}-{account}", "-");
-                Task.Run(async () => await _keyVaultClient.SetSecretAsync(_configuration[VaultUriName], name, password));
+                Task.Run(async () => await _secretsClient.SetSecretAsync(name, password));
                 return true;
             }
             catch (Exception ex)

--- a/ExternalPlugins/HashiCorpVault/Manifest.json
+++ b/ExternalPlugins/HashiCorpVault/Manifest.json
@@ -3,5 +3,5 @@
  	"Name": "HashiCorpVault",
 	"DisplayName": "HashiCorp Vault",
 	"Assembly": "HashiCorpVault.dll",
-	"Version": "1.0.0.9999"
+	"Version": "1.1.0.9999"
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ## [Note]
 
-Due to an upgraded version of the SignalR technology in Safeguard for Privileged Passwords, a matching SignalR client version had to be upgraded in the Safeguard Secrets Broker for DevOps.  The upgraded SignalR technology that is used to monitor the password change events, is not backwards compatible with previous versions.  Therefore, version 1.5.0 and above of the Safeguard Secrets Broker for DevOps is only compatible with Safeguard for Privileged Passwords 6.8.0 and above.  The Safeguard Secrets Broker for DevOps 1.0.0 must be used with versions of Safeguard for Privileged Passwords 6.7.0 or below.
+* There has been a major library upgrade to the Azure Key Vault plugin version 2.x which will break the configuration for previous versions of the plugin. To fix the Azure Key Vault plugin after upgrading, edit the plugin configuration and add the TenantId/DirectoryId of the key vault. Once the configuration has been updated, the Azure Key Vault plugin should continue to work as expected.
+
+* Due to an upgraded version of the SignalR technology in Safeguard for Privileged Passwords, a matching SignalR client version had to be upgraded in the Safeguard Secrets Broker for DevOps.  The upgraded SignalR technology that is used to monitor the password change events, is not backwards compatible with previous versions.  Therefore, version 1.5.0 and above of the Safeguard Secrets Broker for DevOps is only compatible with Safeguard for Privileged Passwords 6.8.0 and above.  The Safeguard Secrets Broker for DevOps 1.0.0 must be used with versions of Safeguard for Privileged Passwords 6.7.0 or below.
 
 # Safeguard Secrets Broker for DevOps
 


### PR DESCRIPTION
Bump the version number to 2.x and also bump the revision number of other plugins that included minor updates.  Add a note to the README.md page to notify the user of the breaking change to the Azure Key Vault plugin.