### PR TITLE
Fix a couple of bugs when turning off monitoring and viewing the plugin edit page.

### DIFF
--- a/SafeguardDevOpsService/ClientApp/src/app/service-client.service.ts
+++ b/SafeguardDevOpsService/ClientApp/src/app/service-client.service.ts
@@ -249,7 +249,7 @@ export class DevOpsServiceClient {
       // Ignore 404 Not Found, when there is no vault account
       .pipe(catchError((err) => {
         if (err.status === 404) {
-          return throwError(of(undefined));
+          return of(null);
         } else {
           return throwError(this.error<any>('getPluginVaultAccount'));
         }

--- a/SafeguardDevOpsService/Logic/MonitoringLogic.cs
+++ b/SafeguardDevOpsService/Logic/MonitoringLogic.cs
@@ -137,7 +137,11 @@ namespace OneIdentity.DevOps.Logic
         {
             try
             {
-                _eventListener?.Stop();
+                try
+                {
+                    _eventListener?.Stop();
+                } catch { }
+
                 _a2AContext?.Dispose();
                 _logger.Information("Password change monitoring has been stopped.");
             }


### PR DESCRIPTION
If a vault account is not provided in the edit plugin dialog, the dialog will fail to show any managed accounts that exist due to the vault account throwing a 404 exception. Also skip any errors when the monitoring is stopping after monitoring has already failed to start.