### PR TITLE
Enhance the API /plugins/{name}/accounts with a count and includeAllInstances query params

### DIFF
--- a/SafeguardDevOpsService/Controllers/V1/PluginsController.cs
+++ b/SafeguardDevOpsService/Controllers/V1/PluginsController.cs
@@ -242,9 +242,15 @@ namespace OneIdentity.DevOps.Controllers.V1
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpGet("{name}/Accounts")]
-        public ActionResult<IEnumerable<AccountMapping>> GetAccountMapping([FromServices] IPluginsLogic pluginsLogic, [FromRoute] string name)
+        public ActionResult<IEnumerable<AccountMapping>> GetAccountMapping([FromServices] IPluginsLogic pluginsLogic, 
+            [FromRoute] string name, [FromQuery] bool count = false, [FromQuery] bool includeAllInstances = false)
         {
-            var accountMappings = pluginsLogic.GetAccountMappings(name);
+            var accountMappings = pluginsLogic.GetAccountMappings(name, includeAllInstances);
+
+            if (count)
+            {
+                return Ok(accountMappings.Count());
+            }
 
             return Ok(accountMappings);
         }

--- a/SafeguardDevOpsService/Logic/IPluginsLogic.cs
+++ b/SafeguardDevOpsService/Logic/IPluginsLogic.cs
@@ -22,7 +22,7 @@ namespace OneIdentity.DevOps.Logic
         Plugin SavePluginConfigurationByName(PluginConfiguration pluginConfiguration, string name);
         Plugin CreatePluginInstanceByName(string name, bool copyConfig);
 
-        IEnumerable<AccountMapping> GetAccountMappings(string name);
+        IEnumerable<AccountMapping> GetAccountMappings(string name, bool includeAllInstances = false);
         AccountMapping GetAccountMappingById(string name, int accountId);
         IEnumerable<AccountMapping> SaveAccountMappings(ISafeguardConnection sgConnection, string name, IEnumerable<A2ARetrievableAccount> accounts);
         void DeleteAccountMappings(string name);

--- a/SafeguardDevOpsService/Logic/PluginsLogic.cs
+++ b/SafeguardDevOpsService/Logic/PluginsLogic.cs
@@ -269,9 +269,10 @@ namespace OneIdentity.DevOps.Logic
             return new PluginState() {Disabled = plugin.IsDisabled};
         }
 
-        public IEnumerable<AccountMapping> GetAccountMappings(string name)
+        public IEnumerable<AccountMapping> GetAccountMappings(string name, bool includeAllInstances = false)
         {
-            if (_configDb.GetPluginByName(name) == null)
+            var plugin = _configDb.GetPluginByName(name);
+            if (plugin == null)
             {
                 var msg = $"Plugin {name} not found";
                 _logger.Error(msg);
@@ -280,7 +281,9 @@ namespace OneIdentity.DevOps.Logic
 
             var mappings = _configDb.GetAccountMappings();
 
-            var accountMappings = mappings.Where(x => x.VaultName.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+            var accountMappings = includeAllInstances ? mappings.Where(x => x.VaultName.StartsWith(plugin.RootPluginName, StringComparison.InvariantCultureIgnoreCase)) :
+                mappings.Where(x => x.VaultName.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+
             return accountMappings;
         }
 


### PR DESCRIPTION
This gets the count of account for each account in the list for a single plugin instance or for all plugin instances.  If count is false but includeAllInstances is true, then the list include all accounts for all instances.