### PR TITLE
Add monitoring APIs for getting and setting the reverse flow interval and status. 

### DIFF
--- a/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/IConfigurationRepository.cs
@@ -37,6 +37,8 @@ namespace OneIdentity.DevOps.ConfigDb
         int? AssetAccountGroupId { get; set; }
         string SigningCertificate { get; set; }
         string LastKnownMonitorState { get; set; }
+        string LastKnownReverseFlowMonitorState { get; set; }
+        int? ReverseFlowPollingInterval { get; set; }
 
         string UserCertificateThumbprint { get; set; }
         string UserCertificateBase64Data { get; set; }

--- a/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
+++ b/SafeguardDevOpsService/ConfigDb/LiteDbConfigurationRepository.cs
@@ -47,6 +47,8 @@ namespace OneIdentity.DevOps.ConfigDb
         private const string AssetAccountGroupIdKey = "AssetAccountGroupId";
         private const string SigningCertificateKey = "SigningCertificate";
         private const string LastKnownMonitorStateKey = "LastKnownMonitorState";
+        private const string LastKnownReverseFlowMonitorStateKey = "LastKnownReverseFlowMonitorState";
+        private const string ReverseFlowPollingIntervalKey = "ReverseFlowPollingInterval";
 
         private const string UserCertificateThumbprintKey = "UserCertThumbprint";
         private const string UserCertificateDataKey = "UserCertData";
@@ -447,7 +449,7 @@ namespace OneIdentity.DevOps.ConfigDb
             {
                 try
                 {
-                    return Int32.Parse(GetSimpleSetting(A2aUserIdKey));
+                    return int.Parse(GetSimpleSetting(A2aUserIdKey));
                 }
                 catch
                 {
@@ -463,7 +465,7 @@ namespace OneIdentity.DevOps.ConfigDb
             {
                 try
                 {
-                    return Int32.Parse(GetSimpleSetting(A2aRegistrationIdKey));
+                    return int.Parse(GetSimpleSetting(A2aRegistrationIdKey));
                 }
                 catch
                 {
@@ -479,7 +481,7 @@ namespace OneIdentity.DevOps.ConfigDb
             {
                 try
                 {
-                    return Int32.Parse(GetSimpleSetting(A2aVaultRegistrationIdKey));
+                    return int.Parse(GetSimpleSetting(A2aVaultRegistrationIdKey));
                 }
                 catch
                 {
@@ -495,7 +497,7 @@ namespace OneIdentity.DevOps.ConfigDb
             {
                 try
                 {
-                    return Int32.Parse(GetSimpleSetting(AssetIdKey));
+                    return int.Parse(GetSimpleSetting(AssetIdKey));
                 }
                 catch
                 {
@@ -511,7 +513,7 @@ namespace OneIdentity.DevOps.ConfigDb
             {
                 try
                 {
-                    return Int32.Parse(GetSimpleSetting(AssetPartitionIdKey));
+                    return int.Parse(GetSimpleSetting(AssetPartitionIdKey));
                 }
                 catch
                 {
@@ -527,7 +529,7 @@ namespace OneIdentity.DevOps.ConfigDb
             {
                 try
                 {
-                    return Int32.Parse(GetSimpleSetting(AssetAccountGroupIdKey));
+                    return int.Parse(GetSimpleSetting(AssetAccountGroupIdKey));
                 }
                 catch
                 {
@@ -541,6 +543,32 @@ namespace OneIdentity.DevOps.ConfigDb
         {
             get => GetSimpleSetting(LastKnownMonitorStateKey);
             set => SetSimpleSetting(LastKnownMonitorStateKey, value);
+        }
+
+        public string LastKnownReverseFlowMonitorState
+        {
+            get => GetSimpleSetting(LastKnownReverseFlowMonitorStateKey);
+            set => SetSimpleSetting(LastKnownReverseFlowMonitorStateKey, value);
+        }
+
+        public int? ReverseFlowPollingInterval
+        {
+            get
+            {
+                try
+                {
+                    return int.Parse(GetSimpleSetting(ReverseFlowPollingIntervalKey));
+                }
+                catch
+                {
+                    return WellKnownData.ReverseFlowMonitorPollingInterval;
+                }
+            }
+            set
+            {
+                value ??= WellKnownData.ReverseFlowMonitorPollingInterval;
+                SetSimpleSetting(ReverseFlowPollingIntervalKey, value.ToString());
+            }
         }
 
         public string SigningCertificate

--- a/SafeguardDevOpsService/Controllers/V2/MonitorController.cs
+++ b/SafeguardDevOpsService/Controllers/V2/MonitorController.cs
@@ -26,33 +26,33 @@ namespace OneIdentity.DevOps.Controllers.V2
         }
 
         /// <summary>
-        /// Get the current state of the A2A monitor.
+        /// Get the current state of the A2A and Reverse Flow monitoring.
         /// </summary>
         /// <remarks>
         /// Safeguard Secrets Broker for DevOps monitors the associated Safeguard for Privileged Passwords appliance for any password change to any account that
         /// has been registered with Safeguard Secrets Broker for DevOps.  
         ///
-        /// This endpoint gets the current state of the account monitor.
+        /// This endpoint gets the current state of the A2A and Reverse Flow monitoring.
         /// </remarks>
         /// <response code="200">Success</response>
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpGet]
-        public ActionResult<MonitorState> GetMonitor([FromServices] IMonitoringLogic monitoringLogic)
+        public ActionResult<FullMonitorState> GetMonitorState([FromServices] IMonitoringLogic monitoringLogic)
         {
-            var monitoring = monitoringLogic.GetMonitorState();
+            var monitoring = monitoringLogic.GetFullMonitorState();
 
             return Ok(monitoring);
         }
 
         /// <summary>
-        /// Set the state of the A2A monitor.
+        /// Force a new state of A2A and Reverse Flow monitoring.
         /// </summary>
         /// <remarks>
         /// Safeguard Secrets Broker for DevOps monitors the associated Safeguard for Privileged Passwords appliance for any password change to any account that
         /// has been registered with Safeguard Secrets Broker for DevOps.  
         ///
-        /// This endpoint starts or stops the account monitor.
+        /// This endpoint forces a new state of both the A2A and Reverse Flow monitoring.
         /// </remarks>
         /// <param name="monitorState">New state of the monitor.</param>
         /// <response code="200">Success</response>
@@ -60,11 +60,33 @@ namespace OneIdentity.DevOps.Controllers.V2
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
         [HttpPost]
-        public ActionResult<MonitorState> GetMonitor([FromServices] IMonitoringLogic monitoringLogic, MonitorState monitorState)
+        public ActionResult<FullMonitorState> ForceMonitorState([FromServices] IMonitoringLogic monitoringLogic, MonitorState monitorState)
         {
             monitoringLogic.EnableMonitoring(monitorState.Enabled);
 
-            return Ok(monitorState);
+            return Ok(monitoringLogic.GetFullMonitorState());
+        }
+
+        /// <summary>
+        /// Set the state of the A2A or the Reverse Flow monitoring.
+        /// </summary>
+        /// <remarks>
+        /// Safeguard Secrets Broker for DevOps monitors the associated Safeguard for Privileged Passwords appliance for any password change to any account that
+        /// has been registered with Safeguard Secrets Broker for DevOps.  
+        ///
+        /// This endpoint sets a new state of the A2A or Reverse Flow monitoring.
+        /// </remarks>
+        /// <param name="fullMonitorState">New state of the monitor.</param>
+        /// <response code="200">Success</response>
+        /// <response code="400">Bad Request</response>
+        [SafeguardSessionKeyAuthorization]
+        [UnhandledExceptionError]
+        [HttpPut]
+        public ActionResult<FullMonitorState> SetMonitorState([FromServices] IMonitoringLogic monitoringLogic, FullMonitorState fullMonitorState)
+        {
+            monitoringLogic.EnableMonitoring(fullMonitorState);
+
+            return Ok(monitoringLogic.GetFullMonitorState());
         }
 
         /// <summary>
@@ -89,19 +111,59 @@ namespace OneIdentity.DevOps.Controllers.V2
         }
 
         /// <summary>
-        /// Start a reverse flow polling cycle.
+        /// Get the current state of the Reverse Flow monitor.
         /// </summary>
         /// <remarks>
-        /// Safeguard Secrets Broker for DevOps monitors the associated Safeguard for Privileged Passwords appliance for any password change to any account that
+        /// Safeguard Secrets Broker for DevOps reverser flow monitors the associated third party vaults for any password change to any account that
         /// has been registered with Safeguard Secrets Broker for DevOps.  
         ///
-        /// This endpoint starts a reverse flow polling cycle outside of monitoring.
+        /// This endpoint gets the current state of the Reverse Flow monitor.
+        /// </remarks>
+        /// <response code="200">Success</response>
+        [SafeguardSessionKeyAuthorization]
+        [UnhandledExceptionError]
+        [HttpGet("ReverseFlow")]
+        public ActionResult<ReverseFlowMonitorState> GetReverseFlowMonitorState([FromServices] IMonitoringLogic monitoringLogic)
+        {
+            var monitoring = monitoringLogic.GetReverseFlowMonitorState();
+
+            return Ok(monitoring);
+        }
+
+        /// <summary>
+        /// Set the current state of the Reverse Flow monitor.
+        /// </summary>
+        /// <remarks>
+        /// Safeguard Secrets Broker for DevOps reverser flow monitors the associated third party vaults for any password change to any account that
+        /// has been registered with Safeguard Secrets Broker for DevOps.  
+        ///
+        /// This endpoint sets the current state of the Reverse Flow monitor.
+        /// </remarks>
+        /// <response code="200">Success</response>
+        [SafeguardSessionKeyAuthorization]
+        [UnhandledExceptionError]
+        [HttpPut("ReverseFlow")]
+        public ActionResult<ReverseFlowMonitorState> SetReverseFlowMonitorState([FromServices] IMonitoringLogic monitoringLogic, ReverseFlowMonitorState reverseFlowMonitorState)
+        {
+            var monitoring = monitoringLogic.SetReverseFlowMonitorState(reverseFlowMonitorState);
+
+            return Ok(monitoring);
+        }
+
+        /// <summary>
+        /// Force a single Reverse Flow polling cycle.
+        /// </summary>
+        /// <remarks>
+        /// Safeguard Secrets Broker for DevOps reverser flow monitors the associated third party vaults for any password change to any account that
+        /// has been registered with Safeguard Secrets Broker for DevOps.  
+        ///
+        /// This endpoint forces a single Reverse Flow polling cycle outside of monitoring.
         /// </remarks>
         /// <response code="200">Success</response>
         /// <response code="400">Bad Request</response>
         [SafeguardSessionKeyAuthorization]
         [UnhandledExceptionError]
-        [HttpPost("ReverseFlow")]
+        [HttpPost("ReverseFlow/PollNow")]
         public ActionResult PollReverseFlow([FromServices] IMonitoringLogic monitoringLogic)
         {
             if (!monitoringLogic.PollReverseFlow())

--- a/SafeguardDevOpsService/Data/FullMonitorState.cs
+++ b/SafeguardDevOpsService/Data/FullMonitorState.cs
@@ -1,0 +1,14 @@
+﻿
+namespace OneIdentity.DevOps.Data
+{
+    /// <summary>
+    /// Full monitor state
+    /// </summary>
+    public class FullMonitorState : MonitorState
+    {
+        /// <summary>
+        /// Reverse flow monitor state
+        /// </summary>
+        public ReverseFlowMonitorState ReverseFlowMonitorState { get; set; }
+    }
+}

--- a/SafeguardDevOpsService/Data/MonitorState.cs
+++ b/SafeguardDevOpsService/Data/MonitorState.cs
@@ -10,10 +10,5 @@ namespace OneIdentity.DevOps.Data
         /// Is monitor enabled
         /// </summary>
         public bool Enabled { get; set; }
-
-        /// <summary>
-        /// Is reverse flow monitor enabled
-        /// </summary>
-        public bool ReverseFlowEnabled { get; set; }
     }
 }

--- a/SafeguardDevOpsService/Data/ReverseFlowMonitorState.cs
+++ b/SafeguardDevOpsService/Data/ReverseFlowMonitorState.cs
@@ -1,0 +1,19 @@
+﻿
+namespace OneIdentity.DevOps.Data
+{
+    /// <summary>
+    /// Reverse flow monitor state
+    /// </summary>
+    public class ReverseFlowMonitorState
+    {
+        /// <summary>
+        /// Is reverse flow monitor enabled
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Reverse flow polling interval
+        /// </summary>
+        public int ReverseFlowPollingInterval { get; set; }
+    }
+}

--- a/SafeguardDevOpsService/Logic/IMonitoringLogic.cs
+++ b/SafeguardDevOpsService/Logic/IMonitoringLogic.cs
@@ -7,9 +7,13 @@ namespace OneIdentity.DevOps.Logic
     public interface IMonitoringLogic
     {
         void EnableMonitoring(bool enable);
+        void EnableMonitoring(FullMonitorState FullmonitorState);
         MonitorState GetMonitorState();
+        FullMonitorState GetFullMonitorState();
         IEnumerable<MonitorEvent> GetMonitorEvents(int size);
         bool PollReverseFlow();
         void Run();
+        ReverseFlowMonitorState GetReverseFlowMonitorState();
+        ReverseFlowMonitorState SetReverseFlowMonitorState(ReverseFlowMonitorState reverseFlowMonitorState);
     }
 }

--- a/SafeguardDevOpsService/Logic/MonitoringLogic.cs
+++ b/SafeguardDevOpsService/Logic/MonitoringLogic.cs
@@ -4,12 +4,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
-using System.Runtime.CompilerServices;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using OneIdentity.DevOps.Common;
 using OneIdentity.DevOps.ConfigDb;
 using OneIdentity.DevOps.Data;
@@ -302,12 +300,6 @@ namespace OneIdentity.DevOps.Logic
             {
                 _logger.Information("Listener is already running.");
             }
-
-            // if (monitorState.ReverseFlowMonitorState.Enabled && !_isA2AMonitoringEnabled)
-            // {
-            //     StartReverseFlowMonitor();
-            //     _logger.Information("Reverse flow monitoring has been started.");
-            // }
         }
 
         private void StopMonitoring()

--- a/SafeguardDevOpsService/Logic/MonitoringLogic.cs
+++ b/SafeguardDevOpsService/Logic/MonitoringLogic.cs
@@ -51,23 +51,118 @@ namespace OneIdentity.DevOps.Logic
             return CertificateHelper.CertificateValidation(sender, certificate, chain, sslPolicyErrors, _logger, _configDb);
         }
 
+        private bool _isA2AMonitoringEnabled => _eventListener != null && _a2AContext != null;
+
         public void EnableMonitoring(bool enable)
         {
-            if (enable)
-                StartMonitoring();
-            else
-                StopMonitoring();
+            // Force the enable state for A2A and reverseflow monitoring.
+            var newState = new FullMonitorState()
+            {
+                Enabled = enable,
+                ReverseFlowMonitorState = null
+            };
 
-            _configDb.LastKnownMonitorState = GetMonitorState().Enabled ? WellKnownData.MonitorEnabled : WellKnownData.MonitorDisabled;
+            EnableMonitoring(newState);
+        }
+
+        public void EnableMonitoring(FullMonitorState monitorState)
+        {
+            // If no reverse flow monitor state was provided, assume it needs to follow
+            //  the A2A monitor state.
+            if (monitorState.ReverseFlowMonitorState == null)
+            {
+                monitorState.ReverseFlowMonitorState = new ReverseFlowMonitorState()
+                {
+                    Enabled = monitorState.Enabled,
+                    ReverseFlowPollingInterval = _configDb.ReverseFlowPollingInterval ?? WellKnownData.ReverseFlowMonitorPollingInterval
+                };
+            }
+
+            // If the A2A monitor should start and is stopped, start it.
+            if (monitorState.Enabled && !_isA2AMonitoringEnabled)
+            {
+                StartMonitoring();
+            }
+
+            // If the reverse flow monitor should start and is stopped, start it.
+            if (monitorState.ReverseFlowMonitorState.Enabled && !_reverseFlowEnabled)
+            {
+                StartReverseFlowMonitor();
+            }
+
+            // If the A2A monitor should stop and it is running, stop it.
+            if (!monitorState.Enabled && _isA2AMonitoringEnabled)
+            {
+                StopMonitoring();
+            }
+
+            // If the reverse flow monitor should stopt and is running, stop it.
+            if (!monitorState.ReverseFlowMonitorState.Enabled && _reverseFlowEnabled)
+            {
+                StopReverseFlowMonitor();
+            }
+
+            var state = GetFullMonitorState();
+            _configDb.LastKnownMonitorState = state.Enabled ? WellKnownData.MonitorEnabled : WellKnownData.MonitorDisabled;
+            _configDb.LastKnownReverseFlowMonitorState = state.ReverseFlowMonitorState.Enabled ? WellKnownData.MonitorEnabled : WellKnownData.MonitorDisabled;
         }
 
         public MonitorState GetMonitorState()
         {
             return new MonitorState()
             {
-                Enabled = _eventListener != null && _a2AContext != null,
-                ReverseFlowEnabled = _reverseFlowEnabled
+                Enabled = _isA2AMonitoringEnabled,
             };
+        }
+
+        public FullMonitorState GetFullMonitorState()
+        {
+            return new FullMonitorState()
+            {
+                Enabled = _isA2AMonitoringEnabled,
+                ReverseFlowMonitorState = GetReverseFlowMonitorState()
+            };
+        }
+
+        public ReverseFlowMonitorState GetReverseFlowMonitorState()
+        {
+            return new ReverseFlowMonitorState()
+            {
+                Enabled = _reverseFlowEnabled,
+                ReverseFlowPollingInterval = _configDb.ReverseFlowPollingInterval ?? WellKnownData.ReverseFlowMonitorPollingInterval
+            };
+        }
+
+        public ReverseFlowMonitorState SetReverseFlowMonitorState(ReverseFlowMonitorState reverseFlowMonitorState)
+        {
+            if (reverseFlowMonitorState == null)
+            {
+                var msg = "The reverse flow monitor cannot be null.";
+                _logger.Error(msg);
+                throw new DevOpsException(msg);
+            }
+
+            if (_configDb.ReverseFlowPollingInterval != reverseFlowMonitorState.ReverseFlowPollingInterval)
+            {
+                _configDb.ReverseFlowPollingInterval = reverseFlowMonitorState.ReverseFlowPollingInterval;
+            }
+
+            // If the reverse flow monitor should start and is not running, start it.
+            if (reverseFlowMonitorState.Enabled && !_reverseFlowEnabled)
+            {
+                StartReverseFlowMonitor();
+            }
+            // If the reverse flow monitor should stop and is running, stop it.
+            if (!reverseFlowMonitorState.Enabled && _reverseFlowEnabled)
+            {
+                StopReverseFlowMonitor();
+            }
+
+            _configDb.LastKnownReverseFlowMonitorState = reverseFlowMonitorState.Enabled
+                ? WellKnownData.MonitorEnabled
+                : WellKnownData.MonitorDisabled;
+
+            return GetReverseFlowMonitorState();
         }
 
         public IEnumerable<MonitorEvent> GetMonitorEvents(int size)
@@ -95,7 +190,9 @@ namespace OneIdentity.DevOps.Logic
                 var a2AContext = _a2AContext ?? ConnectA2AContext();
                 if (a2AContext == null)
                 {
-                    throw new DevOpsException("Failed to connect to Safeguard A2A service. Monitoring cannot be started.");
+                    var msg = "Failed to connect to Safeguard A2A service. Monitoring cannot be started.";
+                    _logger.Error(msg);
+                    throw new DevOpsException(msg);
                 }
 
                 Task.Run(() => PollReverseFlowInternal(a2AContext));
@@ -111,10 +208,23 @@ namespace OneIdentity.DevOps.Logic
         {
             try
             {
+                // If the A2A monitoring was enabled before the restart, then monitoring on startup.
                 if (_configDb.LastKnownMonitorState != null &&
                     _configDb.LastKnownMonitorState.Equals(WellKnownData.MonitorEnabled))
                 {
                     StartMonitoring();
+                }
+                else
+                {
+                    // Make sure that the last state of the reverse flow is set to disabled if no monitoring started.
+                    _configDb.LastKnownReverseFlowMonitorState = WellKnownData.MonitorDisabled;
+                }
+
+                // If reverse flow monitoring was enabled before the restart, then start monitoring on startup.
+                if (_configDb.LastKnownReverseFlowMonitorState != null &&
+                    _configDb.LastKnownReverseFlowMonitorState.Equals(WellKnownData.MonitorEnabled))
+                {
+                    StartReverseFlowMonitor();
                 }
             }
             catch (Exception ex)
@@ -143,53 +253,61 @@ namespace OneIdentity.DevOps.Logic
 
         private void StartMonitoring()
         {
-            if (_eventListener != null)
-                throw new DevOpsException("Listener is already running.");
-
-            var ignoreSsl = _configDb.IgnoreSsl;
-            if (ignoreSsl.HasValue && ignoreSsl.Value)
-                throw new DevOpsException("Monitoring cannot be enabled until a secure connection has been established. Trusted certificates may be missing.");
-
-            // connect to Safeguard
-            _a2AContext = ConnectA2AContext();
-            if (_a2AContext == null) 
-                throw new DevOpsException("Failed to connect to Safeguard A2A service. Monitoring cannot be started.");
-
-            // This call will fail if the monitor is being started as part of the service start up.
-            //  The reason why is because at service startup, the user has not logged into Secrets Broker yet
-            //  so Secrets Broker does not have the SPP credentials that are required to query the current vault account credentials.
-            //  However, the monitor can still be started using the existing vault credentials. If syncing doesn't appear to be working
-            //  the monitor can be stopped and restarted which will cause a refresh of the vault credentials.
-            _pluginManager.RefreshPluginCredentials();
-
-            // Make sure that the credentialManager cache is empty.
-            _credentialManager.Clear();
-
-            // figure out what API keys to monitor
-            _retrievableAccounts = _configDb.GetAccountMappings().ToList();
-            if (_retrievableAccounts.Count == 0)
+            if (!_isA2AMonitoringEnabled)
             {
-                var msg = "No accounts have been mapped to plugins.  Nothing to do.";
-                _logger.Error(msg);
-                throw new DevOpsException(msg);
+                var ignoreSsl = _configDb.IgnoreSsl;
+                if (ignoreSsl.HasValue && ignoreSsl.Value)
+                    throw new DevOpsException(
+                        "Monitoring cannot be enabled until a secure connection has been established. Trusted certificates may be missing.");
+
+                // connect to Safeguard
+                _a2AContext = ConnectA2AContext();
+                if (_a2AContext == null)
+                    throw new DevOpsException(
+                        "Failed to connect to Safeguard A2A service. Monitoring cannot be started.");
+
+                // This call will fail if the monitor is being started as part of the service start up.
+                //  The reason why is because at service startup, the user has not logged into Secrets Broker yet
+                //  so Secrets Broker does not have the SPP credentials that are required to query the current vault account credentials.
+                //  However, the monitor can still be started using the existing vault credentials. If syncing doesn't appear to be working
+                //  the monitor can be stopped and restarted which will cause a refresh of the vault credentials.
+                _pluginManager.RefreshPluginCredentials();
+
+                // Make sure that the credentialManager cache is empty.
+                _credentialManager.Clear();
+
+                // figure out what API keys to monitor
+                _retrievableAccounts = _configDb.GetAccountMappings().ToList();
+                if (_retrievableAccounts.Count == 0)
+                {
+                    var msg = "No accounts have been mapped to plugins.  Nothing to do.";
+                    _logger.Error(msg);
+                    throw new DevOpsException(msg);
+                }
+
+                var apiKeys = new List<SecureString>();
+                foreach (var account in _retrievableAccounts)
+                {
+                    apiKeys.Add(account.ApiKey.ToSecureString());
+                }
+
+                _eventListener = _a2AContext.GetPersistentA2AEventListener(apiKeys, PasswordChangeHandler);
+                _eventListener.Start();
+
+                InitialPasswordPull();
+
+                _logger.Information("Password change monitoring has been started.");
+            }
+            else
+            {
+                _logger.Information("Listener is already running.");
             }
 
-            var apiKeys = new List<SecureString>();
-            foreach (var account in _retrievableAccounts)
-            {
-                apiKeys.Add(account.ApiKey.ToSecureString());
-            }
-
-            _eventListener = _a2AContext.GetPersistentA2AEventListener(apiKeys, PasswordChangeHandler);
-            _eventListener.Start();
-
-            InitialPasswordPull();
-
-            _logger.Information("Password change monitoring has been started.");
-
-            StartReverseFlowMonitor();
-            _logger.Information("Reverse flow monitoring has been started.");
-
+            // if (monitorState.ReverseFlowMonitorState.Enabled && !_isA2AMonitoringEnabled)
+            // {
+            //     StartReverseFlowMonitor();
+            //     _logger.Information("Reverse flow monitoring has been started.");
+            // }
         }
 
         private void StopMonitoring()
@@ -199,17 +317,21 @@ namespace OneIdentity.DevOps.Logic
                 try
                 {
                     _eventListener?.Stop();
-                } catch { }
+                    _logger.Information("Password change monitoring has been stopped.");
+                }
+                catch
+                {
+                }
 
-                StopReverseFlowMonitor();
-
-                _a2AContext?.Dispose();
-                _logger.Information("Password change monitoring has been stopped.");
+                if (!_reverseFlowEnabled)
+                {
+                    _a2AContext?.Dispose();
+                    _a2AContext = null;
+                }
             }
             finally
             {
                 _eventListener = null;
-                _a2AContext = null;
                 _retrievableAccounts = null;
                 _credentialManager.Clear();
             }
@@ -341,7 +463,7 @@ namespace OneIdentity.DevOps.Logic
 
         private void StartReverseFlowMonitor()
         {
-            if (ReverseFlowMonitoringAvailable())
+            if (!_reverseFlowEnabled && ReverseFlowMonitoringAvailable())
             {
                 if (_cts == null)
                 {
@@ -411,14 +533,15 @@ namespace OneIdentity.DevOps.Logic
                 {
                     try
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(WellKnownData.ReverseFlowMonitorPollingInterval), token);
+                        var delayTime = _configDb.ReverseFlowPollingInterval ?? WellKnownData.ReverseFlowMonitorPollingInterval;
+                        await Task.Delay(TimeSpan.FromSeconds(delayTime), token);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
                         _logger.Information("Reverse flow monitor thread shutting down.");
                     }
 
-                    if (token.IsCancellationRequested || !GetMonitorState().Enabled)
+                    if (token.IsCancellationRequested || !GetFullMonitorState().ReverseFlowMonitorState.Enabled)
                         break;
 
                     PollReverseFlowInternal(_a2AContext);
@@ -427,6 +550,12 @@ namespace OneIdentity.DevOps.Logic
             finally
             {
                 _reverseFlowEnabled = false;
+                _cts = null;
+                if (!_isA2AMonitoringEnabled)
+                {
+                    _a2AContext?.Dispose();
+                    _a2AContext = null;
+                }
             }
         }
 


### PR DESCRIPTION
Make sure that starting and stopping the A2A monitor and the reverse flow monitor all work independently.  The UI will still treat them as a single monitoring unit.