### PR TITLE
Implement a warning if Secrets Broker detects that SPP does not support reverse flow.

### DIFF
--- a/ExternalPlugins/SmsTextEmail/PluginDescriptor.cs
+++ b/ExternalPlugins/SmsTextEmail/PluginDescriptor.cs
@@ -156,7 +156,8 @@ namespace OneIdentity.DevOps.SmsTextEmail
                 Body = altAccountName != null ? $"{altAccountName}\n{password[0]}" : $"{asset} - {account}\n{password[0]}"
             };
 
-            return StoreCredential(message);
+            StoreCredential(message);
+            return password[0];
         }
 
         private string SetSshKey(string asset, string account, string[] sshKey, string altAccountName)
@@ -173,7 +174,8 @@ namespace OneIdentity.DevOps.SmsTextEmail
                 Body = altAccountName != null ? $"{altAccountName}\n{sshKey[0]}" : $"{asset} - {account}\n{sshKey[0]}"
             };
 
-            return StoreCredential(message);
+            StoreCredential(message);
+            return sshKey[0];
         }
 
         private string SetApiKey(string asset, string account, string[] apiKeys, string altAccountName)

--- a/ExternalPlugins/SppSecrets/SppSecrets.csproj
+++ b/ExternalPlugins/SppSecrets/SppSecrets.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="7.4.0-dev-16824" />
+    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="7.4.0-dev-18496" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 * The plugin interface has been changed to support the Reverse Flow functionality. Due to this interface change, older plugins will no longer load. Once Secrets Broker has been upgraded, each of the plugins will also need to be upgraded as well. The Secrets Broker user interface will indicate which plugins need to be upgraded and allow the user to download and upgrade the plugin. Once all of the plugins have been upgraded, the Secrets Broker service will need to be restart.
 
-* All of the functionality in this version of Secrets Broker is backwards compatible with versions of Safeguard 7.0.0 and above with the exception of the Reverse Flow feature. The Reverse Flow feature depends on changes that are only available in Safeguard 7.4 and above. If the Secrets Broker service is connected to a version of Safeguard that is less than 7.4, Secrets Broker will continue to work but the Reverse Flow feature will be unavailable.
+* All of the functionality in this version of Secrets Broker is backwards compatible with versions of Safeguard 7.0.0 and above with the exception of the Reverse Flow feature. The Reverse Flow feature depends on changes that are only available in Safeguard 7.4 and above. If the Secrets Broker service is connected to a version of Safeguard that is less than 7.4, Secrets Broker will continue to work but the Reverse Flow feature will be unavailable. A small indicator will appear in the bottom left-hand corner of the main window if Secrets Broker is unable to provide the Reverse Flow feature.
 
 # Safeguard Secrets Broker for DevOps
 
@@ -130,7 +130,7 @@ With the ability designate a plugin instance as Reverse Flow, Secrets Broker int
 
 1. Copy the installer MSI package to the local file system of a Windows 10 or Windows Server 2016 or better, computer.
 1. Open a PowerShell command window as an administrator and invoke the above MSI installer package.
-1. Follow all prompts - This will deploy the package and automatically start it as a Windows service.
+1. Follow all prompts - This will deploy the package and automatically start it as a Windows service. If prompted to stop services during the installation, click the ```Ignore``` button to allow the installation to continue.
 1. At start up, Safeguard Secrets Broker for DevOps will create a new folder under the ```/ProgramData``` directory as ```/SafeguardDevOpsService```.  This folder will contain the log file, database and the external plugins folder.  The external plugins folder will be initially empty (See Deploying Vault Plugins).
 1. Make sure that the firewall on the Windows computer has an inbound rule for allowing https port 443.
 1. Acquire a valid login token to SPP.  Use the Powershell cmdlet (See <https://github.com/OneIdentity/safeguard-ps>):
@@ -227,14 +227,20 @@ Initialization of the Secrets Broker on Windows or as a Docker image can be cont
 
 ![SafeguardDevOpsService](Images/SafeguardDevOpsMonitoring-1.png)
 
-### Monitoring Password Events and Trouble Shooting
+### Monitoring Credential Events and Trouble Shooting
 
-The Safeguard Secrets Broker for DevOps provides ways to monitor the password events and trouble shooting.  This functionality can be found under the system menu.  To access the system menu, select the cog icon in the upper right-hand corner of the browser window.  The system menu contains several options such as restarting the Safeguard Secrets Broker for DevOps, deleting the current configuration which resets the system to the default state as well as downloading the system log and viewing the password event history.
+The Safeguard Secrets Broker for DevOps provides ways for monitoring credential events and trouble shooting.  This functionality can be found under the system menu.  To access the system menu, select the cog icon in the upper right-hand corner of the browser window.  The system menu contains several options such as restarting the Safeguard Secrets Broker for DevOps, deleting the current configuration which resets the system to the default state as well as downloading the system log and viewing the monitor event history.
 
 * To trouble shoot issues that may arise, select the Download Log option from the System Menu.  The system log will provide details about a system issue or error that may have occurred.
-* To view the password events, select the View Monitor Event History option from the System Menu.  The Monitor Events will appear which contains a list of the password events that have taken place since the system was last started.  These events are only stored in memory which means that each time that the Safeguard Secrets Broker for DevOps is restarted, the list will be cleared.
+* To view the credential events, select the View Monitor Event History option from the System Menu.  The Monitor Events will appear which contains a list of the credential events that have taken place since the monitoring was last started.  These events are only stored in memory which means that each time that the Safeguard Secrets Broker for DevOps is restarted, the list will be cleared.
 
 ![SafeguardDevOpsService](Images/SafeguardDevOpsServiceMonitorEventsList-1.PNG)
+
+### Common Monitoring Issues
+
+* The A2A credential change listener has disconnected. If this happens, the Monitor Events History will show that the listener has changed state to ```Disconnected```. There are a few reason why this may happen.
+  * The Safeguard appliance has not be configured with a valid SSL/TLS certificate. Secrets Broker cannot establish a connection to the A2A event service if the Safeguard appliance is still configured with the default SSL/TLS certificate or an invalid certificate. Make sure that the SSL/TLS certificate has a valid subject name and a valid Alternate DNS Name or Alternate IP Address. Please see the Safeguard admin guide for further information. In addition, the matching public certificate must be installed as a trusted root certificate in the Windows Certificate Store of the computer that is hosting the Secrets Broker service. See [Installing the trusted root certificate](https://learn.microsoft.com/en-us/skype-sdk/sdn/articles/installing-the-trusted-root-certificate) for more information.
+  * The IP address of the Secrets Broker host has changed and the A2A registration restrictions are preventing Secrets Broker from accessing the credentials. Secrets Broker automatically places IP restriction on each credential retrieval entry. This is to help prevent other services from access the same credentials. If the IP address of the Secrets Broker service has changes, the restriction may be preventing Secrets Broker from accessing the credentials as well. Modify or add the Secrets Broker IP address to the restrictions list for the credential retrieval entry under the A2A registrations that match the Secrets Broker instance.
 
 ### Configuring Multiple Plugin Instances
 
@@ -249,6 +255,8 @@ Just below the ```Plugin Settings``` banner, Secrets Broker shows the number of 
 ### Reverse Flow
 
 Configuring a Secrets Broker plugin instance as Reverse Flow is done by simply checking the ```Reverse Flow``` checkbox in the ```Configuration``` section of the ```Plugin Settings``` page. This causes Secrets Broker to call the plugin instance when any of the registered account credentials need to be fetched rather than pushed.
+
+The Reverse Flow feature is only available if Secrets Broker is connected to a Safeguard appliance version 7.4.0 or above. Reverse Flow may also be unavailable if the ```Allow Setting Credentials``` flag on the ```SafeguardDevOpsServer-<Id>``` A2A registration in the Safeguard appliance has been disabled. If Secrets Broker detects that the connected Safeguard appliance does not provide the necessary support for Reverse Flow, a small indicator will appear in the bottom left corner of the main page. In addition, all Reverse Flow functionality will be disabled including the Reverse Flow monitor and the Reverse Flow checkbox on the plugin configuration.
 
 ![SafeguardDevOpsService](Images/ReverseFlowCheckbox.PNG)
 

--- a/SafeguardDevOpsService/ClientApp/src/app/edit-plugin.service.ts
+++ b/SafeguardDevOpsService/ClientApp/src/app/edit-plugin.service.ts
@@ -22,6 +22,7 @@ export class EditPluginService {
 
   public instanceIndex: number = 0;
   public pluginInstances = [];
+  public reverseFlowAvailable: boolean = false;
 
   public get plugin() {
     return this.pluginInstances[this.instanceIndex];

--- a/SafeguardDevOpsService/ClientApp/src/app/edit-plugin/edit-plugin.component.html
+++ b/SafeguardDevOpsService/ClientApp/src/app/edit-plugin/edit-plugin.component.html
@@ -76,7 +76,7 @@
           matTooltip="Disable the plugin to prevent monitoring the associated accounts">Disabled</mat-checkbox>
       </div>
       <div class="reverse-flag">
-        <mat-checkbox color="primary" *ngIf="!plugin.IsSystemOwned" [disabled]="!plugin.SupportsReverseFlow" [(ngModel)]="plugin.ReverseFlowEnabled"
+        <mat-checkbox color="primary" *ngIf="!plugin.IsSystemOwned" [disabled]="!plugin.Supports || !ReverseFlowAvailable" [(ngModel)]="plugin.ReverseFlowEnabled"
           [matTooltip]="plugin.SupportsReverseFlow ? 'Enable reverse flow for this plugin instance. Reverse flow pulls credentials from the vault' : 'This plugin does not support reverse flow'">Reverse Flow</mat-checkbox>
       </div>
       <div *ngIf="!plugin.IsSystemOwned" class="sub-title-2">Plugin Details</div>

--- a/SafeguardDevOpsService/ClientApp/src/app/edit-plugin/edit-plugin.component.ts
+++ b/SafeguardDevOpsService/ClientApp/src/app/edit-plugin/edit-plugin.component.ts
@@ -49,6 +49,9 @@ export class EditPluginComponent implements OnInit {
   public get instanceCount() {
     return this.editPluginService.pluginInstances.length;
   }
+  public get reverseFlowAvailable() {
+    return this.editPluginService.reverseFlowAvailable;
+  }
 
   ngOnInit(): void {
     this.editPluginService.pluginInstances.forEach(p => {

--- a/SafeguardDevOpsService/ClientApp/src/app/main/main.component.html
+++ b/SafeguardDevOpsService/ClientApp/src/app/main/main.component.html
@@ -324,6 +324,7 @@
     </ng-container>
 
     <div [ngClass]="{'footer': true, 'footer-absolute': footerAbsolute}">Version: {{DevOpsVersion}}</div>
+    <div class='footer-left' *ngIf="!ReverseFlowAvailable">*Reverse Flow monitoring is not available</div>
 
     <div class="svg-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">

--- a/SafeguardDevOpsService/ClientApp/src/app/main/main.component.scss
+++ b/SafeguardDevOpsService/ClientApp/src/app/main/main.component.scss
@@ -48,6 +48,13 @@ mat-drawer-container {
   padding-bottom: 15px;
 }
 
+.footer-left {
+  color: $muted-red;
+  position: fixed;
+  bottom: 15px;
+  left: 15px;
+}
+
 .footer-absolute {
   position: fixed;
   bottom: 0;
@@ -115,11 +122,11 @@ mat-drawer-container {
     font-size: .85em;
     color: $black-9;
   }
-  
+
   .vertical-line {
     border-right: 1px solid $black-c;
   }
-  
+
   .green-icon {
     color: $aspen-green;
     vertical-align: top;
@@ -152,7 +159,7 @@ mat-drawer-container {
       margin-top: -15px;
     }
   }
-  
+
   .loading-container{
     width: 100%;
     padding-left: 30px;
@@ -167,7 +174,7 @@ mat-drawer-container {
 }
 
 .plugin-container.unconfigured {
-  border: 2px dashed $black-9; 
+  border: 2px dashed $black-9;
   color: $black-6;
   display: flex;
   margin-bottom: 20px;

--- a/SafeguardDevOpsService/ClientApp/src/app/main/main.component.ts
+++ b/SafeguardDevOpsService/ClientApp/src/app/main/main.component.ts
@@ -80,6 +80,7 @@ export class MainComponent implements OnInit, AfterViewInit {
   isAssetAdmin: boolean = false;
   certificateUploaded: boolean = false;
   passedTrustChainValidation: boolean = false;
+  ReverseFlowAvailable: boolean = false;
   passphrase: string;
   pluginInstances = [];
 
@@ -353,6 +354,7 @@ export class MainComponent implements OnInit, AfterViewInit {
         this.needsTrustedCertificates = logon.NeedsTrustedCertificates;
         this.needsSSLEnabled = logon.NeedsSSLEnabled;
         this.passedTrustChainValidation = logon.PassedTrustChainValidation;
+        this.ReverseFlowAvailable = logon.ReverseFlowAvailable;
       }),
       switchMap(() => this.checkA2ARegistration()),
       tap((nullRegistration: any) => {
@@ -587,6 +589,7 @@ export class MainComponent implements OnInit, AfterViewInit {
     this.error = null;
     let pluginInstances = cloneDeep(this.plugins.filter(p => p.RootPluginName == plugin.RootPluginName));
     this.editPluginService.openProperties(pluginInstances);
+    this.editPluginService.reverseFlowAvailable = this.ReverseFlowAvailable;
     this.openWhat = 'plugin';
     this.openDrawer = 'properties';
     this.drawer.open();
@@ -757,7 +760,23 @@ export class MainComponent implements OnInit, AfterViewInit {
       error => {
         this.error = error;
       });
-  }
+
+    setTimeout(() => {
+      if (enabled === true) {
+        this.serviceClient.getMonitor().pipe(
+          untilDestroyed(this)
+        ).subscribe(
+          (status: any) => {
+            if (status.StatusMessage != null) {
+              this.snackBar.open(status.StatusMessage, 'Dismiss', { duration: 10000 });
+            }
+          },
+          error => {
+            this.snackBar.open('Failed to get the monitor status: ' + this.error, 'Dismiss', { duration: 10000});
+          });
+      }
+    }, 3000);
+}
 
   logout(): void {
     this.error = null;

--- a/SafeguardDevOpsService/ClientApp/src/app/view-monitor-events/view-monitor-events.component.html
+++ b/SafeguardDevOpsService/ClientApp/src/app/view-monitor-events/view-monitor-events.component.html
@@ -6,6 +6,23 @@
   </mat-toolbar>
 
   <div class="main-container">
+
+    <mat-card>
+      <div class="monitor-status-header">
+        <h2>Monitor Status</h2>
+      </div>
+      <div class="info-label">Status</div>
+      <div>{{GetMonitorStatus()}}</div>
+      <p></p>
+      <div class="info-label">Reverse Flow Monitor</div>
+      <div>{{GetReverseFlowMonitorStatus()}}</div>
+      <p></p>
+      <div class="info-label">Monitor Issues</div>
+      <div>{{monitorStatusMessage}}</div>
+    </mat-card>
+
+    <p></p>
+
     <div class="table-container" [ngClass]="{'hidden': isLoading}">
       <table mat-table [dataSource]="dataSource">
 

--- a/SafeguardDevOpsService/ClientApp/src/app/view-monitor-events/view-monitor-events.component.scss
+++ b/SafeguardDevOpsService/ClientApp/src/app/view-monitor-events/view-monitor-events.component.scss
@@ -6,6 +6,20 @@
   height: 100%;
 }
 
+.monitor-status-header {
+  display: flex;
+  align-items: baseline;
+}
+
+.info-label {
+  font-size: .85em;
+  color: $black-9;
+}
+
+.sub-title {
+  color: $black-9;
+}
+
 table {
   width: 100%;
 }

--- a/SafeguardDevOpsService/ClientApp/src/app/view-monitor-events/view-monitor-events.component.ts
+++ b/SafeguardDevOpsService/ClientApp/src/app/view-monitor-events/view-monitor-events.component.ts
@@ -4,6 +4,7 @@ import { EditPluginService } from '../edit-plugin.service';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
+import { tap } from 'rxjs/operators';
 
 @UntilDestroy()
 @Component({
@@ -25,6 +26,12 @@ export class ViewMonitorEventsComponent implements OnInit, AfterViewInit {
   isLoading: boolean;
   dataSource = new MatTableDataSource([]);
   totalCount = 0;
+  monitorStatus: string = "";
+  a2aMonitorStatus: string = "";
+  reverseFlowMonitorStatus: string = "";
+  monitoringStatusMessage: string = "";
+  monitoring: string = "";
+  monitorStatusMessage: string = "";
 
   ngOnInit(): void {
     this.displayedColumns = ['Event', 'Date'];
@@ -50,10 +57,34 @@ export class ViewMonitorEventsComponent implements OnInit, AfterViewInit {
         this.dataSource.data = this.events;
       }
     );
+    this.serviceClient.getMonitor().pipe(
+      untilDestroyed(this),
+    ).subscribe(
+      (status: any) => {
+        this.monitorStatus = status.Enabled;
+        this.monitorStatusMessage = status.StatusMessage;
+        this.reverseFlowMonitorStatus = status.ReverseFlowMonitorState.Enabled;
+        this.monitoringStatusMessage = status.MonitoringStatusMessage;
+      }
+    );
   }
 
   close(): void {
     this.editPluginService.closeViewMonitorEvents();
+  }
+
+  GetMonitorStatus(): string {
+    if (this.monitorStatus) {
+      return "Running";
+    }
+    return "Stopped";
+  }
+
+  GetReverseFlowMonitorStatus(): string {
+    if (this.reverseFlowMonitorStatus) {
+      return "Running";
+    }
+    return "Stopped";
   }
 
 }

--- a/SafeguardDevOpsService/ClientApp/src/colors.scss
+++ b/SafeguardDevOpsService/ClientApp/src/colors.scss
@@ -7,6 +7,7 @@ $asher-gray: #F2F2F2;
 $gunmetal: #333;
 $aspen-green: #618F3E;
 $phoenix-red: #B42126;
+$muted-red: #c58e90;
 
 $black-6: #666;
 $black-9: #999;
@@ -18,7 +19,7 @@ $maui-sunset: #802981;
 $tiki-sunrise: #F0DF3F;
 $azalea-pink: #F10C8A;
 
-/// Material Design Palettes 
+/// Material Design Palettes
 $iris-blue-palette: (
   50: #E1F5FB,
   100: #B4E6F4,

--- a/SafeguardDevOpsService/Data/FullMonitorState.cs
+++ b/SafeguardDevOpsService/Data/FullMonitorState.cs
@@ -10,5 +10,10 @@ namespace OneIdentity.DevOps.Data
         /// Reverse flow monitor state
         /// </summary>
         public ReverseFlowMonitorState ReverseFlowMonitorState { get; set; }
+
+        /// <summary>
+        /// Monitor status message
+        /// </summary>
+        public string StatusMessage { get; set; }
     }
 }

--- a/SafeguardDevOpsService/Data/SafeguardDevOpsLogon.cs
+++ b/SafeguardDevOpsService/Data/SafeguardDevOpsLogon.cs
@@ -45,5 +45,10 @@ namespace OneIdentity.DevOps.Data
         /// Passed Trust Chain Validation
         /// </summary>
         public bool PassedTrustChainValidation { get; set; }
+
+        /// <summary>
+        /// Is reverse flow available
+        /// </summary>
+        public bool ReverseFlowAvailable { get; set; }
     }
 }

--- a/SafeguardDevOpsService/Logic/AuthorizedCache.cs
+++ b/SafeguardDevOpsService/Logic/AuthorizedCache.cs
@@ -26,7 +26,7 @@ namespace OneIdentity.DevOps.Logic
         {
             lock (InstanceLock)
             {
-                var currentConnection = Find(managementConnection);
+                var currentConnection = Find(managementConnection) ?? Find(managementConnection.SessionKey);
                 if (currentConnection != null)
                     Cache.Remove(currentConnection.SessionKey);
                 Cache.Add(managementConnection.SessionKey, managementConnection);
@@ -50,11 +50,18 @@ namespace OneIdentity.DevOps.Logic
 
         public ServiceConfiguration Find(ServiceConfiguration managementConnection)
         {
-            return Cache.Values.FirstOrDefault(x =>
-                x.Appliance.ApplianceAddress.Equals(managementConnection.Appliance.ApplianceAddress) 
-                && x.User != null  
-                && x.User.PrimaryAuthenticationProvider.Name.Equals(managementConnection.User?.PrimaryAuthenticationProvider?.Name) 
-                && x.User.Name.Equals(managementConnection.User?.Name));
+            try
+            {
+                return Cache.Values.FirstOrDefault(x =>
+                    x.Appliance.ApplianceAddress.Equals(managementConnection.Appliance.ApplianceAddress)
+                    && x.User?.PrimaryAuthenticationProvider?.Name != null
+                    && x.User.PrimaryAuthenticationProvider.Name.Equals(managementConnection.User
+                        ?.PrimaryAuthenticationProvider?.Name)
+                    && x.User?.Name != null
+                    && x.User.Name.Equals(managementConnection.User?.Name));
+            } catch { }
+
+            return null;
         }
 
         public void Remove(string sessionKey)

--- a/SafeguardDevOpsService/Logic/IMonitoringLogic.cs
+++ b/SafeguardDevOpsService/Logic/IMonitoringLogic.cs
@@ -15,5 +15,6 @@ namespace OneIdentity.DevOps.Logic
         void Run();
         ReverseFlowMonitorState GetReverseFlowMonitorState();
         ReverseFlowMonitorState SetReverseFlowMonitorState(ReverseFlowMonitorState reverseFlowMonitorState);
+        bool ReverseFlowMonitoringAvailable();
     }
 }

--- a/SafeguardDevOpsService/Logic/SafeguardLogic.cs
+++ b/SafeguardDevOpsService/Logic/SafeguardLogic.cs
@@ -2025,7 +2025,8 @@ namespace OneIdentity.DevOps.Logic
                 NeedsSSLEnabled = safeguardConnection.IgnoreSsl ?? true,
                 NeedsTrustedCertificates = !_configDb.GetAllTrustedCertificates().Any() || !CheckSslConnection(),
                 NeedsWebCertificate = webSslCertificate?.SubjectName.Name != null && webSslCertificate.SubjectName.Name.Equals(WellKnownData.DevOpsServiceDefaultWebSslCertificateSubject),
-                PassedTrustChainValidation = userCertificate != null ? CertificateHelper.ValidateTrustChain(userCertificate, _configDb, _logger) : false
+                PassedTrustChainValidation = userCertificate != null ? CertificateHelper.ValidateTrustChain(userCertificate, _configDb, _logger) : false,
+                ReverseFlowAvailable = _monitoringLogic().ReverseFlowMonitoringAvailable()
             };
 
             return safeguardLogon;

--- a/SafeguardDevOpsService/Logic/WellKnownData.cs
+++ b/SafeguardDevOpsService/Logic/WellKnownData.cs
@@ -72,6 +72,7 @@ namespace OneIdentity.DevOps.Logic
         public const string DbFileName = "Configuration.db";
 
         public const string BackupFileName = "SecretsBrokerBackupStageFile.zip";
+        public const string MonitorDisconnectedMsg = "The monitor is not in a healthy state. Please check the monitor event history.";
 
         public static readonly string ProgramDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), DevOpsServiceName);
         public static readonly string ServiceDirPath = Path.GetDirectoryName(

--- a/SafeguardDevOpsService/SafeguardDevOpsService.csproj
+++ b/SafeguardDevOpsService/SafeguardDevOpsService.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="7.4.0-dev-16824" />
+    <PackageReference Include="OneIdentity.SafeguardDotNet" Version="7.4.0-dev-18496" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Extensions.Autofac.DependencyInjection" Version="5.0.0" />


### PR DESCRIPTION
Show a warning if the monitor is unhealthy and add documentation to troubleshoot the monitor problem. Add an event to the monitor history whenever the A2A signalR monitor disconnects and reconnects. Fix a null reference when logging in.