### PR TITLE
Fix an account not being added to the external SPP account group.

### DIFF
--- a/ExternalPlugins/SppSecrets/PluginDescriptor.cs
+++ b/ExternalPlugins/SppSecrets/PluginDescriptor.cs
@@ -230,7 +230,9 @@ namespace OneIdentity.DevOps.SppSecrets
 
                 if (_accountGroup != null)
                 {
-                    if (!_accountGroup.Accounts.Any(x => x.Name.Equals(account.Name, StringComparison.OrdinalIgnoreCase)))
+                    if (!_accountGroup.Accounts.Any(x => 
+                            x.Name.Equals(account.Name, StringComparison.OrdinalIgnoreCase) && 
+                            x.Asset.Name.Equals(account.Asset.Name, StringComparison.OrdinalIgnoreCase)))
                     {
                         AddAccountToGroup(account);
                     }


### PR DESCRIPTION
When adding the account to the external SPP account group, check both the account name and the asset name to determine if the account already exists in the group.