### PR TITLE
Fix automatic restart of the monitor when the Secrets Broker service starts

### DIFF
--- a/ExternalPlugins/AzureKeyVault/PluginDescriptor.cs
+++ b/ExternalPlugins/AzureKeyVault/PluginDescriptor.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
-using Newtonsoft.Json;
 using OneIdentity.DevOps.Common;
 using Serilog;
 

--- a/ExternalPlugins/SppSecrets/PluginDescriptor.cs
+++ b/ExternalPlugins/SppSecrets/PluginDescriptor.cs
@@ -62,7 +62,7 @@ namespace OneIdentity.DevOps.SppSecrets
             if (_configuration != null)
             {
                 _sppConnection = Safeguard.Connect(_configuration[SppAppliance], "local", _configuration[SppUser], credential.ToSecureString(), ignoreSsl: true);
-                Logger.Information($"Plugin {Name} has been successfully authenticated to the Azure vault.");
+                Logger.Information($"Plugin {Name} has been successfully authenticated to the Safeguard vault.");
 
                 if (!CheckOrAddExternalA2aRegistration())
                 {

--- a/SafeguardDevOpsService/Data/Plugin.cs
+++ b/SafeguardDevOpsService/Data/Plugin.cs
@@ -51,6 +51,11 @@ namespace OneIdentity.DevOps.Data
         public int? VaultAccountId { get; set; }
 
         /// <summary>
+        /// A2A registration vault account api key
+        /// </summary>
+        public string VaultAccountApiKey { get; set; }
+
+        /// <summary>
         /// Is the plugin loaded
         /// </summary>
         public bool IsLoaded { get; set; }

--- a/SafeguardDevOpsService/Logic/IPluginManager.cs
+++ b/SafeguardDevOpsService/Logic/IPluginManager.cs
@@ -1,4 +1,5 @@
-﻿using OneIdentity.DevOps.Common;
+﻿using System.Collections.Generic;
+using OneIdentity.DevOps.Common;
 using OneIdentity.DevOps.Data;
 using OneIdentity.SafeguardDotNet;
 
@@ -21,6 +22,7 @@ namespace OneIdentity.DevOps.Logic
 
         Plugin DuplicatePlugin(string name, bool copyConfig);
 
-        void RefreshPluginCredentials();
+        bool RefreshPluginCredentials();
+        void RefreshPluginCredentials(List<Plugin> plugins);
     }
 }


### PR DESCRIPTION
When starting the monitor automatically at service startup, the user is not logged in so Secrets Broker cannot get the account API keys for the vault registration.  In this case, Secrets Broker needs to hold on to the last known good api keys and refresh the plugins with that api key.  There is the possibility that an api key was changed on the SPP side.  In which case the plugin will fail to get the current vault credential and be unable to send credentials to the vault. To fix this, the user will have to login and restart the monitor so that Secrets Broker can get the updated api keys.  This code just holds on to the last known good API key for each vault credential.