### PR TITLE
TFS 490896 Code Signing Certificate

### DIFF
--- a/ExternalPlugins/AwsSecretsManagerVault/AwsSecretsManagerVault.csproj
+++ b/ExternalPlugins/AwsSecretsManagerVault/AwsSecretsManagerVault.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
   

--- a/ExternalPlugins/AzureKeyVault/AzureKeyVault.csproj
+++ b/ExternalPlugins/AzureKeyVault/AzureKeyVault.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/ExternalPlugins/CircleCISecrets/CircleCISecrets.csproj
+++ b/ExternalPlugins/CircleCISecrets/CircleCISecrets.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/ExternalPlugins/GithubSecrets/GithubSecrets.csproj
+++ b/ExternalPlugins/GithubSecrets/GithubSecrets.csproj
@@ -31,6 +31,7 @@
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
     <Exec Command="copy &quot;$(OutDir)runtimes\win-x64\native\*.dll&quot; &quot;$(OutDir)&quot;" />
     <Exec Command="rd /S /Q &quot;$(OutDir)runtimes&quot;" />
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/ExternalPlugins/GoogleCloudSecretManager/GoogleCloudSecretManager.csproj
+++ b/ExternalPlugins/GoogleCloudSecretManager/GoogleCloudSecretManager.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/ExternalPlugins/GoogleCloudServiceAccountKeyRotation/GoogleCloudServiceAccountKeyRotation.csproj
+++ b/ExternalPlugins/GoogleCloudServiceAccountKeyRotation/GoogleCloudServiceAccountKeyRotation.csproj
@@ -32,6 +32,7 @@
   <!-- To import the plugin via the Secrets Broker web UI, use the following post build event
   and PowerShell script from the main repository. -->
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/ExternalPlugins/HashiCorpVault/HashiCorpVault.csproj
+++ b/ExternalPlugins/HashiCorpVault/HashiCorpVault.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/ExternalPlugins/JenkinsSecrets/JenkinsSecrets.csproj
+++ b/ExternalPlugins/JenkinsSecrets/JenkinsSecrets.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/ExternalPlugins/KubernetesSecrets/KubernetesSecrets.csproj
+++ b/ExternalPlugins/KubernetesSecrets/KubernetesSecrets.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/ExternalPlugins/SmsTextEmail/SmsTextEmail.csproj
+++ b/ExternalPlugins/SmsTextEmail/SmsTextEmail.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/ExternalPlugins/SppSecrets/SppSecrets.csproj
+++ b/ExternalPlugins/SppSecrets/SppSecrets.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>-->
 
   <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent">
+    <Exec Condition="'$(SignFiles)'=='true'" Command="&quot;$(SignToolPath)&quot; sign /v /fd SHA256 /tr http://ts.ssl.com /td sha256 /n &quot;One Identity LLC&quot; &quot;$(TargetDir)*.dll&quot;" />
     <Exec Command="powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; '$(SolutionDir)zipplugin.ps1' '$(ProjectDir)' '$(OutDir)' '$(SolutionDir)ExternalPlugins\bin\$(Configuration)\' '$(buildId)'&quot;" EchoOff="False" IgnoreExitCode="False" LogStandardErrorAsError="True" ContinueOnError="False" ConsoleToMsBuild="True" />
   </Target>
 

--- a/build-publish.yml
+++ b/build-publish.yml
@@ -73,7 +73,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
     steps:
       - template: pipeline-templates/linux-build-steps.yml
-      - task: AzureKeyVault@1
+      - task: AzureKeyVault@2
         inputs:
           azureSubscription: 'OneIdentity.RD.SBox.Safeguard-ServiceConnection'
           KeyVaultName: 'SafeguardBuildSecrets'
@@ -107,7 +107,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
     steps:
       - template: pipeline-templates/linux-build-steps.yml
-      - task: AzureKeyVault@1
+      - task: AzureKeyVault@2
         inputs:
           azureSubscription: 'OneIdentity.RD.SBox.Safeguard-ServiceConnection'
           KeyVaultName: 'SafeguardBuildSecrets'

--- a/pipeline-templates/windows-build-steps.yml
+++ b/pipeline-templates/windows-build-steps.yml
@@ -45,13 +45,6 @@ steps:
       arguments: '$(Build.SourcesDirectory)\DevOpsAddonCommon\DevOpsAddonCommon.csproj --configuration $(buildConfiguration) --include-symbols -p:SymbolPackageFormat=snupkg --output $(Build.ArtifactStagingDirectory) --no-build --verbosity detailed'
     displayName: Building Addon Common NuGet packages
 
-  - task: DeleteFiles@1
-    inputs:
-      SourceFolder: '$(Build.BinariesDirectory)'
-      Contents: '$(codeSigningCertFileName)'
-    condition: succeededOrFailed()
-    displayName: 'Delete code signing certificate files'
-
   - task: CopyFiles@2
     inputs:
       sourceFolder: '$(Build.SourcesDirectory)\$(setupProjectDir)'

--- a/pipeline-templates/windows-job-variables.yml
+++ b/pipeline-templates/windows-job-variables.yml
@@ -11,7 +11,5 @@ variables:
     value: 'x64'
   - name: buildConfiguration
     value: 'Release'
-  - name: codeSigningCertFileName
-    value: 'OneIdentityCodeSigning.pfx'
   - name: signingToolPath
     value: 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64'


### PR DESCRIPTION
Use AzureKeyVault@2 instead of the deprecated version 1.

No longer need the signing certificate .pfx file variable and cleanup.

Sign all of the plug-in assemblies.