### PR TITLE
TFS 490896 Code Signing Certificate

### DIFF
--- a/SafeguardDevOpsServiceWix/SetupSafeguardDevOpsService.wixproj
+++ b/SafeguardDevOpsServiceWix/SetupSafeguardDevOpsService.wixproj
@@ -24,9 +24,6 @@
     <DefineConstants>SourceDir=bin\$(Configuration)\publish</DefineConstants>
     <SuppressIces>ICE61;ICE63;ICE64</SuppressIces>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\signtool.exe</SignToolPath>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Component-generated.wxs" />
     <Compile Include="Product.wxs" />

--- a/pipeline-templates/windows-build-steps.yml
+++ b/pipeline-templates/windows-build-steps.yml
@@ -17,7 +17,7 @@ steps:
 - task: VSBuild@1
   inputs:
     solution: '$(solution)'
-    msbuildArgs: '/p:SignFiles=true /p:buildId=$(Build.BuildId)'
+    msbuildArgs: '/p:SignFiles=true /p:buildId=$(Build.BuildId) /p:SignToolPath="C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\signtool.exe"'
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
   displayName: 'Build $(solution) with signing'

--- a/pipeline-templates/windows-job-variables.yml
+++ b/pipeline-templates/windows-job-variables.yml
@@ -1,15 +1,13 @@
 variables:
-  - name: solution
-    value: '**/*.sln'
-  - name: setupProjectDir
-    value: 'SafeguardDevOpsServiceWix'
-  - name: setupProject
-    value: '**/$(setupProjectDir)/*.wixproj'
-  - name: pluginsDir
-    value: 'ExternalPlugins'
-  - name: buildPlatform
-    value: 'x64'
-  - name: buildConfiguration
-    value: 'Release'
-  - name: signingToolPath
-    value: 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64'
+- name: solution
+  value: '**/*.sln'
+- name: setupProjectDir
+  value: 'SafeguardDevOpsServiceWix'
+- name: setupProject
+  value: '**/$(setupProjectDir)/*.wixproj'
+- name: pluginsDir
+  value: 'ExternalPlugins'
+- name: buildPlatform
+  value: 'x64'
+- name: buildConfiguration
+  value: 'Release'


### PR DESCRIPTION
All projects need the `SignToolPath` build variable. Pass it in as another build argument.